### PR TITLE
feat: upload-images command with local processing mode

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -184,7 +184,6 @@ async function main() {
         environment: process.env.NODE_ENV || 'production',
     });
 
-    let config;
     try {
         const args = await yargs(hideBin(process.argv))
             .command('$0', 'Deploy Storybook static build', (yargs) => {
@@ -257,7 +256,7 @@ async function main() {
                     });
             }, async (argv) => {
                 // Load and merge configuration
-                config = loadConfig(argv);
+                const config = loadConfig(argv);
 
                 // Validate required fields
                 if (!config.dir) {
@@ -313,7 +312,7 @@ async function main() {
                     });
             }, async (argv) => {
                 // Load and merge configuration
-                config = loadConfig(argv);
+                const config = loadConfig(argv);
 
                 await runAnalysis(config);
             })
@@ -474,7 +473,7 @@ async function main() {
                         type: 'boolean',
                     });
             }, async (argv) => {
-                config = loadConfig(argv);
+                const config = loadConfig(argv);
 
                 if (!config.dir) {
                     throw new Error('--dir is required. Provide a path to the image directory.');
@@ -489,26 +488,26 @@ async function main() {
 
                 if (config.local) {
                     // Local mode: process images directly via LLM + embeddings + Milvus
-                    const openaiApiKey = config.openaiApiKey || process.env.OPENAI_API_KEY;
-                    const jinaApiKey = config.jinaApiKey || process.env.JINA_API_KEY;
-                    const milvusAddress = config.milvusAddress || process.env.MILVUS_ADDRESS;
-                    const milvusToken = config.milvusToken || process.env.MILVUS_TOKEN;
-                    const milvusCollection = config.milvusCollection || process.env.MILVUS_COLLECTION;
+                    const requiredLocalKeys = {
+                        openaiApiKey: { flag: '--openai-api-key', env: 'OPENAI_API_KEY' },
+                        jinaApiKey: { flag: '--jina-api-key', env: 'JINA_API_KEY' },
+                        milvusAddress: { flag: '--milvus-address', env: 'MILVUS_ADDRESS' },
+                        milvusToken: { flag: '--milvus-token', env: 'MILVUS_TOKEN' },
+                        milvusCollection: { flag: '--milvus-collection', env: 'MILVUS_COLLECTION' },
+                    };
 
-                    if (!openaiApiKey) throw new Error('--openai-api-key or OPENAI_API_KEY env var is required for local mode');
-                    if (!jinaApiKey) throw new Error('--jina-api-key or JINA_API_KEY env var is required for local mode');
-                    if (!milvusAddress) throw new Error('--milvus-address or MILVUS_ADDRESS env var is required for local mode');
-                    if (!milvusToken) throw new Error('--milvus-token or MILVUS_TOKEN env var is required for local mode');
-                    if (!milvusCollection) throw new Error('--milvus-collection or MILVUS_COLLECTION env var is required for local mode');
+                    const resolved = {};
+                    for (const [key, { flag, env }] of Object.entries(requiredLocalKeys)) {
+                        resolved[key] = config[key] || process.env[env];
+                        if (!resolved[key]) {
+                            throw new Error(`${flag} or ${env} env var is required for local mode`);
+                        }
+                    }
 
                     await runLocalImageProcessing({
                         dir: config.dir,
                         project: config.project,
-                        openaiApiKey,
-                        jinaApiKey,
-                        milvusAddress,
-                        milvusToken,
-                        milvusCollection,
+                        ...resolved,
                         verbose: config.verbose,
                     });
                 } else {
@@ -525,7 +524,7 @@ async function main() {
             .parse();
 
     } catch (error) {
-        await handleError(error, config);
+        await handleError(error, error.config || {});
     }
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,6 +19,7 @@ const { postPRComment } = require('../lib/pr-comment.js');
 const { runInit } = require('../lib/init.js');
 const { runUpdateWorkflows } = require('../lib/update-workflows.js');
 const { runQueueImageUpload } = require('../lib/imageUpload.js');
+const { runLocalImageProcessing } = require('../lib/localImageProcessing.js');
 
 async function runAnalysis(argv) {
     const logger = createLogger(argv);
@@ -435,12 +436,37 @@ async function main() {
                         type: 'string',
                         demandOption: true,
                     })
+                    .option('local', {
+                        describe: 'Process images locally instead of uploading to the queue',
+                        type: 'boolean',
+                        default: false,
+                    })
+                    .option('openai-api-key', {
+                        describe: 'OpenAI API key (for --local mode)',
+                        type: 'string',
+                    })
+                    .option('jina-api-key', {
+                        describe: 'Jina API key (for --local mode)',
+                        type: 'string',
+                    })
+                    .option('milvus-address', {
+                        describe: 'Milvus/Zilliz endpoint (for --local mode)',
+                        type: 'string',
+                    })
+                    .option('milvus-token', {
+                        describe: 'Milvus/Zilliz auth token (for --local mode)',
+                        type: 'string',
+                    })
+                    .option('milvus-collection', {
+                        describe: 'Milvus collection name (for --local mode)',
+                        type: 'string',
+                    })
                     .option('api-key', {
-                        describe: 'API key for the deployment service',
+                        describe: 'API key for the deployment service (queue mode)',
                         type: 'string',
                     })
                     .option('api-url', {
-                        describe: 'Base URL for the deployment service API',
+                        describe: 'Base URL for the deployment service API (queue mode)',
                         type: 'string',
                     })
                     .option('verbose', {
@@ -461,7 +487,33 @@ async function main() {
                     throw new Error(`Path is not a directory: ${config.dir}`);
                 }
 
-                await runQueueImageUpload(config);
+                if (config.local) {
+                    // Local mode: process images directly via LLM + embeddings + Milvus
+                    const openaiApiKey = config.openaiApiKey || process.env.OPENAI_API_KEY;
+                    const jinaApiKey = config.jinaApiKey || process.env.JINA_API_KEY;
+                    const milvusAddress = config.milvusAddress || process.env.MILVUS_ADDRESS;
+                    const milvusToken = config.milvusToken || process.env.MILVUS_TOKEN;
+                    const milvusCollection = config.milvusCollection || process.env.MILVUS_COLLECTION;
+
+                    if (!openaiApiKey) throw new Error('--openai-api-key or OPENAI_API_KEY env var is required for local mode');
+                    if (!jinaApiKey) throw new Error('--jina-api-key or JINA_API_KEY env var is required for local mode');
+                    if (!milvusAddress) throw new Error('--milvus-address or MILVUS_ADDRESS env var is required for local mode');
+                    if (!milvusToken) throw new Error('--milvus-token or MILVUS_TOKEN env var is required for local mode');
+                    if (!milvusCollection) throw new Error('--milvus-collection or MILVUS_COLLECTION env var is required for local mode');
+
+                    await runLocalImageProcessing({
+                        dir: config.dir,
+                        project: config.project,
+                        openaiApiKey,
+                        jinaApiKey,
+                        milvusAddress,
+                        milvusToken,
+                        milvusCollection,
+                        verbose: config.verbose,
+                    });
+                } else {
+                    await runQueueImageUpload(config);
+                }
             })
             .command('debug-sentry', 'Test Sentry integration by throwing an error', () => {}, () => {
                 throw new Error('Sentry debug error from scry-node CLI');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,6 +18,7 @@ const { runCoverageAnalysis, loadCoverageReport, extractCoverageSummary } = requ
 const { postPRComment } = require('../lib/pr-comment.js');
 const { runInit } = require('../lib/init.js');
 const { runUpdateWorkflows } = require('../lib/update-workflows.js');
+const { runQueueImageUpload } = require('../lib/imageUpload.js');
 
 async function runAnalysis(argv) {
     const logger = createLogger(argv);
@@ -421,6 +422,46 @@ async function main() {
                 };
 
                 await runInit(initConfig);
+            })
+            .command('upload-images', 'Upload a folder of images for search indexing', (yargs) => {
+                return yargs
+                    .option('dir', {
+                        describe: 'Path to the image directory',
+                        type: 'string',
+                        demandOption: true,
+                    })
+                    .option('project', {
+                        describe: 'Project name/identifier',
+                        type: 'string',
+                        demandOption: true,
+                    })
+                    .option('api-key', {
+                        describe: 'API key for the deployment service',
+                        type: 'string',
+                    })
+                    .option('api-url', {
+                        describe: 'Base URL for the deployment service API',
+                        type: 'string',
+                    })
+                    .option('verbose', {
+                        describe: 'Enable verbose logging',
+                        type: 'boolean',
+                    });
+            }, async (argv) => {
+                config = loadConfig(argv);
+
+                if (!config.dir) {
+                    throw new Error('--dir is required. Provide a path to the image directory.');
+                }
+
+                if (!fs.existsSync(config.dir)) {
+                    throw new Error(`Directory not found: ${config.dir}`);
+                }
+                if (!fs.lstatSync(config.dir).isDirectory()) {
+                    throw new Error(`Path is not a directory: ${config.dir}`);
+                }
+
+                await runQueueImageUpload(config);
             })
             .command('debug-sentry', 'Test Sentry integration by throwing an error', () => {}, () => {
                 throw new Error('Sentry debug error from scry-node CLI');

--- a/lib/apiClient.js
+++ b/lib/apiClient.js
@@ -153,14 +153,15 @@ function validatePresignedUrl(presignedUrl) {
  * Upload a buffer to a presigned URL.
  *
  * @param {string} presignedUrl
- * @param {Buffer} buffer
+ * @param {Buffer|import('stream').Readable} data
  * @param {string} contentType
  * @returns {Promise<{status:number}>}
  */
-async function putToPresignedUrl(presignedUrl, buffer, contentType) {
-  logger.debug(`Starting PUT upload to presigned URL. Size: ${buffer.length} bytes, Content-Type: ${contentType}`);
+async function putToPresignedUrl(presignedUrl, data, contentType) {
+  const size = Buffer.isBuffer(data) ? `${data.length} bytes` : 'stream';
+  logger.debug(`Starting PUT upload to presigned URL. Size: ${size}, Content-Type: ${contentType}`);
   
-  const uploadResponse = await axios.put(presignedUrl, buffer, {
+  const uploadResponse = await axios.put(presignedUrl, data, {
     headers: {
       'Content-Type': contentType,
     },

--- a/lib/imageUpload.js
+++ b/lib/imageUpload.js
@@ -1,0 +1,120 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { zipDirectory } = require('./archive.js');
+const { getApiClient, requestPresignedUrl, putToPresignedUrl } = require('./apiClient.js');
+const { createLogger } = require('./logger.js');
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg']);
+
+/**
+ * Recursively find image files in a directory.
+ * Excludes __MACOSX and hidden files.
+ *
+ * @param {string} dir
+ * @returns {string[]} Array of absolute file paths
+ */
+function findImageFiles(dir) {
+  const results = [];
+
+  function walk(currentDir) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      // Skip hidden files/dirs and __MACOSX
+      if (entry.name.startsWith('.') || entry.name === '__MACOSX') continue;
+
+      const fullPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        const ext = path.extname(entry.name).toLowerCase();
+        if (IMAGE_EXTENSIONS.has(ext)) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+/**
+ * Run queue-mode image upload.
+ * ZIPs the directory, uploads via presigned URL, signals completion.
+ *
+ * @param {object} config
+ * @param {string} config.dir - Path to image directory
+ * @param {string} config.project - Project identifier
+ * @param {string} config.apiKey - API key
+ * @param {string} config.apiUrl - API base URL
+ * @param {boolean} [config.verbose]
+ */
+async function runQueueImageUpload(config) {
+  const logger = createLogger(config);
+
+  // 1. Validate directory and count images
+  logger.info('Scanning for images...');
+  const imageFiles = findImageFiles(config.dir);
+  if (imageFiles.length === 0) {
+    throw new Error(`No image files (.png, .jpg, .jpeg) found in: ${config.dir}`);
+  }
+  logger.success(`Found ${imageFiles.length} images`);
+
+  const zipPath = path.join(os.tmpdir(), `scry-image-upload-${Date.now()}.zip`);
+
+  try {
+    // 2. ZIP the directory
+    logger.info('Creating ZIP archive...');
+    await zipDirectory(config.dir, zipPath);
+    const zipSize = fs.statSync(zipPath).size;
+    logger.success(`ZIP created: ${(zipSize / 1024 / 1024).toFixed(1)} MB`);
+    logger.debug(`ZIP path: ${zipPath}`);
+
+    // 3. Initialize upload — get presigned URL and uploadId
+    logger.info('Initializing upload...');
+    const apiClient = getApiClient(config.apiUrl, config.apiKey);
+
+    const initResponse = await apiClient.post(
+      `/upload-images/${config.project}`,
+      { imageCount: imageFiles.length },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+
+    const { uploadId, uploadNumber, presignedUrl, zipKey } = initResponse.data;
+    logger.info(`Upload #${uploadNumber} initialized (id: ${uploadId})`);
+    logger.debug(`Presigned URL received, zipKey: ${zipKey}`);
+
+    // 4. PUT ZIP to presigned URL
+    logger.info('Uploading ZIP to storage...');
+    const fileBuffer = fs.readFileSync(zipPath);
+    await putToPresignedUrl(presignedUrl, fileBuffer, 'application/zip');
+    logger.success('ZIP uploaded to storage');
+
+    // 5. Signal completion
+    logger.info('Signaling upload complete...');
+    await apiClient.post(
+      `/upload-images/${config.project}/complete`,
+      { uploadId, zipKey },
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+
+    logger.success(`\nUpload #${uploadNumber} queued for processing (${imageFiles.length} images)`);
+    logger.info(`Upload ID: ${uploadId}`);
+
+    return { uploadId, uploadNumber, imageCount: imageFiles.length };
+  } finally {
+    // 6. Cleanup
+    if (fs.existsSync(zipPath)) {
+      fs.unlinkSync(zipPath);
+      logger.debug(`Cleaned up temporary ZIP: ${zipPath}`);
+    }
+  }
+}
+
+module.exports = {
+  findImageFiles,
+  runQueueImageUpload,
+};

--- a/lib/imageUpload.js
+++ b/lib/imageUpload.js
@@ -87,10 +87,10 @@ async function runQueueImageUpload(config) {
     logger.info(`Upload #${uploadNumber} initialized (id: ${uploadId})`);
     logger.debug(`Presigned URL received, zipKey: ${zipKey}`);
 
-    // 4. PUT ZIP to presigned URL
+    // 4. PUT ZIP to presigned URL (stream to avoid loading entire file into memory)
     logger.info('Uploading ZIP to storage...');
-    const fileBuffer = fs.readFileSync(zipPath);
-    await putToPresignedUrl(presignedUrl, fileBuffer, 'application/zip');
+    const fileStream = fs.createReadStream(zipPath);
+    await putToPresignedUrl(presignedUrl, fileStream, 'application/zip');
     logger.success('ZIP uploaded to storage');
 
     // 5. Signal completion

--- a/lib/localImageProcessing.js
+++ b/lib/localImageProcessing.js
@@ -1,55 +1,77 @@
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+const { XMLParser } = require('fast-xml-parser');
 const { createLogger } = require('./logger.js');
 const { findImageFiles } = require('./imageUpload.js');
 
 // ───────────────────────── XML Parsing ─────────────────────────
 
+const xmlParser = new XMLParser({
+  ignoreAttributes: true,
+  trimValues: true,
+});
+
 function parseXmlToJson(xmlContent) {
-  const cleanXml = xmlContent
-    .replace(/<\?xml[^>]*\?>/i, '')
-    .replace(/^\s+|\s+$/g, '')
-    .trim();
+  const wrapped = `<root>${xmlContent}</root>`;
+  const parsed = xmlParser.parse(wrapped);
+  const root = parsed.root || {};
+
+  // Navigate into any wrapper element (e.g. component-documentation)
+  const doc = root['component-documentation'] || root;
 
   const result = {};
 
-  const screenNameMatch = cleanXml.match(/<screen-name>([\s\S]*?)<\/screen-name>/i);
-  if (screenNameMatch) result.screenName = screenNameMatch[1].trim();
+  if (doc['screen-name']) result.screenName = String(doc['screen-name']).trim();
+  if (doc.description) result.description = String(doc.description).trim();
 
-  const descriptionMatch = cleanXml.match(/<description>([\s\S]*?)<\/description>/i);
-  if (descriptionMatch) result.description = descriptionMatch[1].trim();
-
-  const tagsMatch = cleanXml.match(/<tags>([\s\S]*?)<\/tags>/i);
-  if (tagsMatch) {
-    const tagMatches = tagsMatch[1].match(/<tag>(.*?)<\/tag>/gi);
-    result.tags = tagMatches
-      ? tagMatches.map(tag => tag.replace(/<\/?tag>/gi, '').trim())
-      : [];
+  if (doc.tags) {
+    const rawTags = doc.tags.tag;
+    result.tags = Array.isArray(rawTags)
+      ? rawTags.map(t => String(t).trim())
+      : rawTags ? [String(rawTags).trim()] : [];
   }
 
-  const queriesMatch = cleanXml.match(/<search-queries>([\s\S]*?)<\/search-queries>/i);
-  if (queriesMatch) {
-    const queryMatches = queriesMatch[1].match(/<query>(.*?)<\/query>/gi);
-    result.searchQueries = queryMatches
-      ? queryMatches.map(q => q.replace(/<\/?query>/gi, '').trim())
-      : [];
+  if (doc['search-queries']) {
+    const rawQueries = doc['search-queries'].query;
+    result.searchQueries = Array.isArray(rawQueries)
+      ? rawQueries.map(q => String(q).trim())
+      : rawQueries ? [String(rawQueries).trim()] : [];
   }
 
   return result;
 }
 
 function parseBatchXmlResponse(xmlResponse, count) {
-  const componentPattern = /<component-(\d+)>([\s\S]*?)<\/component-\1>/gi;
-  const componentMatches = [...xmlResponse.matchAll(componentPattern)];
+  const wrapped = `<root>${xmlResponse}</root>`;
+  const parsed = xmlParser.parse(wrapped);
+  const root = parsed.root || {};
   const results = [];
 
   for (let i = 0; i < count; i++) {
-    const match = componentMatches.find(m => parseInt(m[1]) === i + 1);
-    if (!match) {
+    const key = `component-${i + 1}`;
+    const component = root[key] || (root['batch-analysis'] && root['batch-analysis'][key]);
+    if (!component) {
       results.push({});
       continue;
     }
-    results.push(parseXmlToJson(`<component-documentation>${match[2]}</component-documentation>`));
+    // Re-serialize the component back to extract fields
+    const result = {};
+    if (component['screen-name']) result.screenName = String(component['screen-name']).trim();
+    if (component.description) result.description = String(component.description).trim();
+    if (component.tags) {
+      const rawTags = component.tags.tag;
+      result.tags = Array.isArray(rawTags)
+        ? rawTags.map(t => String(t).trim())
+        : rawTags ? [String(rawTags).trim()] : [];
+    }
+    if (component['search-queries']) {
+      const rawQueries = component['search-queries'].query;
+      result.searchQueries = Array.isArray(rawQueries)
+        ? rawQueries.map(q => String(q).trim())
+        : rawQueries ? [String(rawQueries).trim()] : [];
+    }
+    results.push(result);
   }
 
   return results;
@@ -176,7 +198,7 @@ async function processBatches(items, batchSize, maxConcurrent, processFn, option
 
 // ───────────────────────── Vector Utils ─────────────────────────
 
-const TARGET_DIM = 2048;
+const DEFAULT_TARGET_DIM = 2048;
 
 function padVector(vector, targetDim) {
   if (!vector || !Array.isArray(vector)) {
@@ -338,7 +360,7 @@ async function callJinaEmbeddings(input, apiKey, maxRetries = 4) {
         },
         body: JSON.stringify({
           model: 'jina-embeddings-v4',
-          task: 'retrieval.query',
+          task: 'retrieval.document',
           input,
         }),
       });
@@ -389,13 +411,13 @@ async function generateTextEmbeddings(texts, apiKey) {
 
 // ───────────────────────── Vector Inserter ─────────────────────────
 
-function transformImageData(image, index, projectId, uploadId) {
+function transformImageData(image, index, projectId, uploadId, targetDim) {
   const timestamp = Date.now();
 
   return {
-    primary_key: timestamp + index,
-    text_embedding: padVector(image.textEmbedding, TARGET_DIM),
-    image_embedding: padVector(image.imageEmbedding, TARGET_DIM),
+    primary_key: crypto.randomUUID(),
+    text_embedding: padVector(image.textEmbedding, targetDim),
+    image_embedding: padVector(image.imageEmbedding, targetDim),
     searchable_text: (image.searchableText || '').substring(0, 65535),
     component_name: image.screenName || 'unknown',
     project_id: projectId,
@@ -414,11 +436,12 @@ function transformImageData(image, index, projectId, uploadId) {
 async function insertImageVectors(images, projectId, uploadId, milvusConfig, options = {}) {
   const batchSize = options.batchSize || 50;
   const maxRetries = options.maxRetries || 1;
+  const targetDim = options.targetDim || DEFAULT_TARGET_DIM;
   let totalInserted = 0;
 
   for (let i = 0; i < images.length; i += batchSize) {
     const batch = images.slice(i, i + batchSize);
-    const records = batch.map((image, idx) => transformImageData(image, i + idx, projectId, uploadId));
+    const records = batch.map((image, idx) => transformImageData(image, i + idx, projectId, uploadId, targetDim));
 
     let lastError = null;
 

--- a/lib/localImageProcessing.js
+++ b/lib/localImageProcessing.js
@@ -1,0 +1,640 @@
+const fs = require('fs');
+const path = require('path');
+const { createLogger } = require('./logger.js');
+const { findImageFiles } = require('./imageUpload.js');
+
+// ───────────────────────── XML Parsing ─────────────────────────
+
+function parseXmlToJson(xmlContent) {
+  const cleanXml = xmlContent
+    .replace(/<\?xml[^>]*\?>/i, '')
+    .replace(/^\s+|\s+$/g, '')
+    .trim();
+
+  const result = {};
+
+  const screenNameMatch = cleanXml.match(/<screen-name>([\s\S]*?)<\/screen-name>/i);
+  if (screenNameMatch) result.screenName = screenNameMatch[1].trim();
+
+  const descriptionMatch = cleanXml.match(/<description>([\s\S]*?)<\/description>/i);
+  if (descriptionMatch) result.description = descriptionMatch[1].trim();
+
+  const tagsMatch = cleanXml.match(/<tags>([\s\S]*?)<\/tags>/i);
+  if (tagsMatch) {
+    const tagMatches = tagsMatch[1].match(/<tag>(.*?)<\/tag>/gi);
+    result.tags = tagMatches
+      ? tagMatches.map(tag => tag.replace(/<\/?tag>/gi, '').trim())
+      : [];
+  }
+
+  const queriesMatch = cleanXml.match(/<search-queries>([\s\S]*?)<\/search-queries>/i);
+  if (queriesMatch) {
+    const queryMatches = queriesMatch[1].match(/<query>(.*?)<\/query>/gi);
+    result.searchQueries = queryMatches
+      ? queryMatches.map(q => q.replace(/<\/?query>/gi, '').trim())
+      : [];
+  }
+
+  return result;
+}
+
+function parseBatchXmlResponse(xmlResponse, count) {
+  const componentPattern = /<component-(\d+)>([\s\S]*?)<\/component-\1>/gi;
+  const componentMatches = [...xmlResponse.matchAll(componentPattern)];
+  const results = [];
+
+  for (let i = 0; i < count; i++) {
+    const match = componentMatches.find(m => parseInt(m[1]) === i + 1);
+    if (!match) {
+      results.push({});
+      continue;
+    }
+    results.push(parseXmlToJson(`<component-documentation>${match[2]}</component-documentation>`));
+  }
+
+  return results;
+}
+
+// ───────────────────────── Prompt ─────────────────────────
+
+const IMAGE_UPLOAD_INSPECTOR_PROMPT = `# UI Screenshot Documentation Instructions
+
+## Overview
+You will analyze UI screenshots (mobile app screens, web pages, or other user interface captures) and generate standardized documentation in XML format consisting of a screen name, description, tags, and search queries.
+
+## Input Materials
+- **Screenshot**: Visual representation of a UI screen
+
+## Output Format (XML Structure)
+
+\`\`\`xml
+<component-documentation>
+  <screen-name>
+    [Short, descriptive name for this screen, e.g. "Home Feed", "Login Page", "Settings Menu"]
+  </screen-name>
+  <description>
+    [2-3 sentence description following the template below]
+  </description>
+  <tags>
+    <tag>Screen Type</tag>
+    <tag>App Category</tag>
+    <tag>Visual Descriptor</tag>
+    <tag>UI Pattern</tag>
+    <tag>Functional Category</tag>
+    <!-- 8-15 total tags -->
+  </tags>
+  <search-queries>
+    <query>UI screen type keyword</query>
+    <query>Visual description phrase</query>
+    <query>User-friendly search phrase</query>
+    <query>Functional description</query>
+    <query>Design pattern query</query>
+    <!-- 5-7 total queries -->
+  </search-queries>
+</component-documentation>
+\`\`\`
+
+## Content Guidelines
+
+### 1. Screen Name (short label)
+- A concise, human-readable name for the screen
+- Examples: "Home Feed", "Product Detail", "Search Results", "User Profile", "Checkout Flow"
+
+### 2. Description (2-3 sentences)
+- **First sentence**: Screen type and primary purpose
+- **Second sentence**: Visual characteristics and key UI elements
+- **Third sentence** (if needed): Notable features or interaction patterns
+
+**Template**: "This is a [screen type] that [primary function]. It features [key UI elements and visual characteristics]. [Additional notable features]."
+
+### 3. Tags (8-15 keywords)
+List relevant tags in this priority order:
+1. Screen type (Home, Settings, Profile, etc.)
+2. App category (Social, E-commerce, Productivity, etc.)
+3. Visual descriptors (colors, layout style)
+4. UI patterns (tab bar, card layout, list view, etc.)
+5. Functional categories (navigation, content, form, etc.)
+6. Platform indicators (iOS, Android, Web)
+
+### 4. Search Queries (5-7 phrases)
+Create search-friendly phrases without quotes:
+- Include screen type + descriptive terms
+- Use common UI/UX terminology
+- Consider both technical and casual language
+- Include design pattern references
+
+## Quality Standards
+- **Accuracy**: Description must match the visual exactly
+- **Completeness**: Include all significant visual and functional aspects
+- **Consistency**: Use the same terminology and format for similar screens
+- **Searchability**: Tags and queries should help users find this screen easily
+- **Valid XML**: Ensure all tags are properly closed and content is escaped if needed
+
+Remember: Accuracy and consistency are critical. When in doubt, describe exactly what you see in the screenshot.`;
+
+// ───────────────────────── Batch Processor ─────────────────────────
+
+async function processBatches(items, batchSize, maxConcurrent, processFn, options = {}) {
+  if (items.length === 0) return [];
+
+  const batches = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    batches.push(items.slice(i, i + batchSize));
+  }
+
+  const results = [];
+  let batchIndex = 0;
+  let completedItems = 0;
+
+  const processBatch = async () => {
+    while (batchIndex < batches.length) {
+      const currentIndex = batchIndex++;
+      const batch = batches[currentIndex];
+
+      if (options.delayMs && currentIndex > 0) {
+        await new Promise(resolve => setTimeout(resolve, options.delayMs));
+      }
+
+      const batchResults = await processFn(batch);
+      results.push(...batchResults);
+      completedItems += batch.length;
+
+      if (options.onProgress) {
+        options.onProgress(completedItems, items.length);
+      }
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(maxConcurrent, batches.length) },
+    () => processBatch()
+  );
+  await Promise.all(workers);
+
+  return results;
+}
+
+// ───────────────────────── Vector Utils ─────────────────────────
+
+const TARGET_DIM = 2048;
+
+function padVector(vector, targetDim) {
+  if (!vector || !Array.isArray(vector)) {
+    return new Array(targetDim).fill(0);
+  }
+  if (vector.length === targetDim) return vector;
+  if (vector.length > targetDim) return vector.slice(0, targetDim);
+  const padded = [...vector];
+  while (padded.length < targetDim) padded.push(0);
+  return padded;
+}
+
+// ───────────────────────── LLM Inspector ─────────────────────────
+
+function createImageBatchPrompt(count) {
+  const batchInstructions = `
+
+## Batch Analysis Instructions
+
+You will analyze ${count} UI screenshot(s) in a single request.
+
+**Format your response as:**
+\`\`\`xml
+<batch-analysis>
+  <component-1>
+    <screen-name>...</screen-name>
+    <description>...</description>
+    <tags><tag>...</tag>...</tags>
+    <search-queries><query>...</query>...</search-queries>
+  </component-1>
+  ${count > 1 ? `<component-2>...</component-2>` : ''}
+  ${count > 2 ? `<!-- ... up to component-${count} -->` : ''}
+</batch-analysis>
+\`\`\`
+
+- Component numbers must match the image order exactly (1st image = component-1, etc.)
+- Each screenshot must have complete documentation including screen-name
+`;
+
+  return IMAGE_UPLOAD_INSPECTOR_PROMPT + batchInstructions;
+}
+
+async function batchInspectImages(images, apiKey, options = {}) {
+  const model = options.model || 'gpt-5-mini';
+  const maxRetries = options.maxRetries ?? 2;
+
+  const batchPrompt = createImageBatchPrompt(images.length);
+
+  const content = [
+    {
+      type: 'text',
+      text: batchPrompt + `\n\nAnalyze these ${images.length} UI screenshots and provide numbered documentation for each.`,
+    },
+  ];
+
+  for (const image of images) {
+    const base64 = image.screenshotBytes.toString('base64');
+    const ext = image.filename.toLowerCase().endsWith('.png') ? 'png' : 'jpeg';
+    content.push({
+      type: 'image_url',
+      image_url: {
+        url: `data:image/${ext};base64,${base64}`,
+        detail: 'high',
+      },
+    });
+  }
+
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          max_completion_tokens: 1500 * images.length,
+          messages: [{ role: 'user', content }],
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`OpenAI API error ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+      const xmlResponse = data.choices?.[0]?.message?.content;
+
+      if (!xmlResponse) {
+        throw new Error('No response content from OpenAI API');
+      }
+
+      const parsedComponents = parseBatchXmlResponse(xmlResponse, images.length);
+
+      return parsedComponents.map((parsed, i) => ({
+        screenName: parsed.screenName || images[i].filename.replace(/\.[^.]+$/, ''),
+        description: parsed.description || '',
+        tags: parsed.tags || [],
+        searchQueries: parsed.searchQueries || [],
+        metadata: {
+          imagePath: images[i].screenshotPath,
+          model,
+          timestamp: new Date().toISOString(),
+          batchIndex: i + 1,
+        },
+      }));
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(`[LLM] Image batch inspection attempt ${attempt + 1} failed:`, lastError.message);
+
+      if (attempt < maxRetries) {
+        await new Promise(resolve => setTimeout(resolve, 2000 * (attempt + 1)));
+      }
+    }
+  }
+
+  throw lastError || new Error('Image batch inspection failed');
+}
+
+// ───────────────────────── Searchable Text ─────────────────────────
+
+function createSearchableTextFromImage(inspection) {
+  if (!inspection) return '';
+
+  const parts = [
+    inspection.screenName || '',
+    inspection.description || '',
+    ...(inspection.tags || []).map(tag => `${tag} element`),
+    ...(inspection.searchQueries || []),
+    'mobile app screen',
+    'UI screenshot',
+    'user interface',
+  ];
+
+  return parts
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// ───────────────────────── Embedding Generator ─────────────────────────
+
+async function callJinaEmbeddings(input, apiKey, maxRetries = 4) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch('https://api.jina.ai/v1/embeddings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'jina-embeddings-v4',
+          task: 'retrieval.query',
+          input,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        const is429 = response.status === 429;
+        const err = new Error(`Jina API error ${response.status}: ${errorText}`);
+        if (is429 && attempt < maxRetries) {
+          const backoff = 15000 * Math.pow(2, attempt);
+          console.warn(`[EMBEDDINGS] Rate limited, waiting ${backoff / 1000}s before retry...`);
+          await new Promise(resolve => setTimeout(resolve, backoff));
+          lastError = err;
+          continue;
+        }
+        throw err;
+      }
+
+      const data = await response.json();
+      if (!data.data) {
+        throw new Error('No embedding data in Jina API response');
+      }
+      return data.data.map(d => d.embedding);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(`[EMBEDDINGS] Attempt ${attempt + 1} failed:`, lastError.message);
+
+      if (attempt < maxRetries) {
+        await new Promise(resolve => setTimeout(resolve, 2000 * (attempt + 1)));
+      }
+    }
+  }
+
+  throw lastError || new Error('Embedding generation failed');
+}
+
+async function generateImageEmbeddings(imageBuffers, apiKey) {
+  const input = imageBuffers.map(buf => ({
+    image: `data:image/png;base64,${buf.toString('base64')}`,
+  }));
+  return callJinaEmbeddings(input, apiKey);
+}
+
+async function generateTextEmbeddings(texts, apiKey) {
+  const input = texts.map(text => ({ text }));
+  return callJinaEmbeddings(input, apiKey);
+}
+
+// ───────────────────────── Vector Inserter ─────────────────────────
+
+function transformImageData(image, index, projectId, uploadId) {
+  const timestamp = Date.now();
+
+  return {
+    primary_key: timestamp + index,
+    text_embedding: padVector(image.textEmbedding, TARGET_DIM),
+    image_embedding: padVector(image.imageEmbedding, TARGET_DIM),
+    searchable_text: (image.searchableText || '').substring(0, 65535),
+    component_name: image.screenName || 'unknown',
+    project_id: projectId,
+    timestamp,
+    json_content: {
+      source_type: 'upload',
+      uploadId,
+      filename: image.filename,
+      screenName: image.screenName,
+      screenshotPath: image.screenshotPath,
+      inspection: image.inspection,
+    },
+  };
+}
+
+async function insertImageVectors(images, projectId, uploadId, milvusConfig, options = {}) {
+  const batchSize = options.batchSize || 50;
+  const maxRetries = options.maxRetries || 1;
+  let totalInserted = 0;
+
+  for (let i = 0; i < images.length; i += batchSize) {
+    const batch = images.slice(i, i + batchSize);
+    const records = batch.map((image, idx) => transformImageData(image, i + idx, projectId, uploadId));
+
+    let lastError = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const base = milvusConfig.address.startsWith('https://') || milvusConfig.address.startsWith('http://')
+          ? milvusConfig.address
+          : `https://${milvusConfig.address}`;
+        const url = `${base.replace(/\/+$/, '')}/v2/vectordb/entities/insert`;
+
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${milvusConfig.token}`,
+          },
+          body: JSON.stringify({
+            collectionName: milvusConfig.collectionName,
+            data: records,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Milvus HTTP error ${response.status}: ${errorText}`);
+        }
+
+        const result = await response.json();
+
+        if (result.code && result.code !== 0) {
+          throw new Error(`Milvus API error (code ${result.code}): ${result.message || JSON.stringify(result)}`);
+        }
+
+        const insertCount = result.data?.insertCount ?? 0;
+        totalInserted += insertCount;
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        console.error(`[MILVUS] Insert attempt ${attempt + 1} failed:`, lastError.message);
+
+        if (attempt < maxRetries) {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        }
+      }
+    }
+
+    if (lastError) throw lastError;
+  }
+
+  return { insertCount: totalInserted };
+}
+
+// ───────────────────────── Orchestrator ─────────────────────────
+
+/**
+ * Run the full local image processing pipeline.
+ * Replicates the worker processUpload() flow but reads from local disk.
+ *
+ * @param {object} config
+ * @param {string} config.dir - Path to image directory
+ * @param {string} config.project - Project identifier
+ * @param {string} config.openaiApiKey - OpenAI API key
+ * @param {string} config.jinaApiKey - Jina API key
+ * @param {string} config.milvusAddress - Milvus/Zilliz endpoint
+ * @param {string} config.milvusToken - Milvus/Zilliz auth token
+ * @param {string} config.milvusCollection - Milvus collection name
+ * @param {boolean} [config.verbose]
+ */
+async function runLocalImageProcessing(config) {
+  const logger = createLogger(config);
+  const startTime = Date.now();
+  const elapsed = () => `${((Date.now() - startTime) / 1000).toFixed(1)}s`;
+
+  // Generate a local upload ID
+  const uploadId = `local-${Date.now()}`;
+
+  logger.info('=== Local Image Processing Pipeline ===');
+  logger.info(`Project: ${config.project}`);
+  logger.info(`Upload ID: ${uploadId}`);
+
+  // Step 1: Find images
+  logger.info('Step 1: Scanning for images...');
+  const imageFiles = findImageFiles(config.dir);
+  if (imageFiles.length === 0) {
+    throw new Error(`No image files (.png, .jpg, .jpeg) found in: ${config.dir}`);
+  }
+  logger.success(`Found ${imageFiles.length} images (${elapsed()})`);
+
+  // Build image items with file bytes
+  const images = imageFiles.map(filePath => {
+    const relativePath = path.relative(config.dir, filePath);
+    return {
+      filename: path.basename(filePath),
+      screenshotPath: relativePath,
+      screenshotBytes: fs.readFileSync(filePath),
+    };
+  });
+
+  // Step 2: LLM Vision Inspection
+  logger.info(`Step 2: LLM inspection for ${images.length} images (batch=5, concurrency=2)...`);
+  const inspectionResults = await processBatches(
+    images,
+    5,
+    2,
+    async (batch) => batchInspectImages(batch, config.openaiApiKey),
+    {
+      delayMs: 2000,
+      onProgress: (done, total) => logger.debug(`  LLM inspection: ${done}/${total} images`),
+    }
+  );
+  logger.success(`LLM inspection complete (${elapsed()})`);
+
+  // Step 3: Create searchable text
+  logger.info('Step 3: Creating searchable text...');
+  const searchableTexts = inspectionResults.map(inspection => createSearchableTextFromImage(inspection));
+  logger.success(`Searchable text created (${elapsed()})`);
+
+  // Step 4: Generate image embeddings
+  logger.info(`Step 4: Generating image embeddings (batch=3, delay=3s)...`);
+  const imageEmbeddings = await processBatches(
+    images.map(img => img.screenshotBytes),
+    3,
+    1,
+    async (batch) => generateImageEmbeddings(batch, config.jinaApiKey),
+    {
+      delayMs: 3000,
+      onProgress: (done, total) => logger.debug(`  Image embeddings: ${done}/${total}`),
+    }
+  );
+  logger.success(`Image embeddings complete (${elapsed()})`);
+
+  // Step 5: Generate text embeddings
+  logger.info(`Step 5: Generating text embeddings (batch=5, delay=2s)...`);
+  const textEmbeddings = await processBatches(
+    searchableTexts,
+    5,
+    1,
+    async (batch) => generateTextEmbeddings(batch, config.jinaApiKey),
+    {
+      delayMs: 2000,
+      onProgress: (done, total) => logger.debug(`  Text embeddings: ${done}/${total}`),
+    }
+  );
+  logger.success(`Text embeddings complete (${elapsed()})`);
+
+  // Step 6: Assemble
+  logger.info('Step 6: Assembling processed images...');
+  const processedImages = [];
+  let failedCount = 0;
+
+  for (let i = 0; i < images.length; i++) {
+    const image = images[i];
+    const inspection = inspectionResults[i];
+    const searchableText = searchableTexts[i];
+    const imageEmbedding = imageEmbeddings[i];
+    const textEmbedding = textEmbeddings[i];
+
+    if (!inspection || !imageEmbedding || !textEmbedding) {
+      failedCount++;
+      continue;
+    }
+
+    processedImages.push({
+      filename: image.filename,
+      screenName: inspection.screenName,
+      screenshotPath: image.screenshotPath,
+      inspection,
+      searchableText,
+      imageEmbedding,
+      textEmbedding,
+    });
+  }
+  logger.success(`Assembled: ${processedImages.length} ok, ${failedCount} failed (${elapsed()})`);
+
+  // Step 7: Insert into Milvus
+  if (processedImages.length > 0) {
+    logger.info(`Step 7: Inserting ${processedImages.length} vectors into Milvus...`);
+    const insertResult = await insertImageVectors(
+      processedImages,
+      config.project,
+      uploadId,
+      {
+        address: config.milvusAddress,
+        token: config.milvusToken,
+        collectionName: config.milvusCollection,
+      }
+    );
+    logger.success(`Milvus insert complete: ${insertResult.insertCount} records (${elapsed()})`);
+  } else {
+    logger.info('Step 7: No images to insert into Milvus');
+  }
+
+  // Summary
+  const status = failedCount === 0
+    ? 'completed'
+    : processedImages.length > 0
+      ? 'partial'
+      : 'failed';
+
+  logger.success(`\n=== Processing Complete (${elapsed()}) ===`);
+  logger.info(`Status: ${status}`);
+  logger.info(`Processed: ${processedImages.length}/${images.length} images`);
+  if (failedCount > 0) logger.info(`Failed: ${failedCount} images`);
+  logger.info(`Upload ID: ${uploadId}`);
+
+  return {
+    uploadId,
+    projectId: config.project,
+    totalImages: images.length,
+    processedImages: processedImages.length,
+    failedImages: failedCount,
+    status,
+  };
+}
+
+module.exports = {
+  runLocalImageProcessing,
+};

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "axios": "^1.12.2",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
+    "fast-xml-parser": "^5.5.7",
     "form-data": "^4.0.0",
     "inquirer": "^8.2.6",
     "open": "^8.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       commander:
         specifier: ^11.1.0
         version: 11.1.0
+      fast-xml-parser:
+        specifier: ^5.5.7
+        version: 5.5.7
       form-data:
         specifier: ^4.0.0
         version: 4.0.5
@@ -1588,6 +1591,13 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-parser@5.5.7:
+    resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2390,6 +2400,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.2.0:
+    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -2772,6 +2786,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@2.2.1:
+    resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -4870,6 +4887,16 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-xml-builder@1.1.4:
+    dependencies:
+      path-expression-matcher: 1.2.0
+
+  fast-xml-parser@5.5.7:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.2.0
+      strnum: 2.2.1
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -5842,6 +5869,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.2.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -6270,6 +6299,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@2.2.1: {}
 
   supports-color@5.5.0:
     dependencies:

--- a/test/imageUpload.test.js
+++ b/test/imageUpload.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { findImageFiles } = require('../lib/imageUpload');
+
+describe('findImageFiles', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scry-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('finds png, jpg, and jpeg files', () => {
+    fs.writeFileSync(path.join(tmpDir, 'screen1.png'), 'fake-png');
+    fs.writeFileSync(path.join(tmpDir, 'screen2.jpg'), 'fake-jpg');
+    fs.writeFileSync(path.join(tmpDir, 'screen3.jpeg'), 'fake-jpeg');
+
+    const files = findImageFiles(tmpDir);
+    expect(files).toHaveLength(3);
+    expect(files.map(f => path.basename(f)).sort()).toEqual(['screen1.png', 'screen2.jpg', 'screen3.jpeg']);
+  });
+
+  it('finds images in nested directories', () => {
+    const subDir = path.join(tmpDir, 'screens', 'mobile');
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(path.join(subDir, 'home.png'), 'data');
+
+    const files = findImageFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('home.png');
+  });
+
+  it('returns empty array for directory with no images', () => {
+    fs.writeFileSync(path.join(tmpDir, 'readme.txt'), 'text');
+    fs.writeFileSync(path.join(tmpDir, 'data.json'), '{}');
+
+    const files = findImageFiles(tmpDir);
+    expect(files).toHaveLength(0);
+  });
+
+  it('skips __MACOSX directories', () => {
+    const macDir = path.join(tmpDir, '__MACOSX');
+    fs.mkdirSync(macDir);
+    fs.writeFileSync(path.join(macDir, '._screen.png'), 'fake');
+    fs.writeFileSync(path.join(tmpDir, 'screen.png'), 'real');
+
+    const files = findImageFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(path.basename(files[0])).toBe('screen.png');
+  });
+
+  it('skips hidden files and directories', () => {
+    const hiddenDir = path.join(tmpDir, '.hidden');
+    fs.mkdirSync(hiddenDir);
+    fs.writeFileSync(path.join(hiddenDir, 'secret.png'), 'data');
+    fs.writeFileSync(path.join(tmpDir, '.dotfile.png'), 'data');
+    fs.writeFileSync(path.join(tmpDir, 'visible.png'), 'data');
+
+    const files = findImageFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(path.basename(files[0])).toBe('visible.png');
+  });
+});

--- a/test/localImageProcessing.test.js
+++ b/test/localImageProcessing.test.js
@@ -1,0 +1,197 @@
+const { runLocalImageProcessing } = require('../lib/localImageProcessing');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Mock global fetch for all API calls
+const originalFetch = global.fetch;
+
+describe('runLocalImageProcessing', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scry-local-test-'));
+    // Create test images
+    fs.writeFileSync(path.join(tmpDir, 'home.png'), Buffer.from([137, 80, 78, 71]));
+    fs.writeFileSync(path.join(tmpDir, 'settings.jpg'), Buffer.from([255, 216, 255]));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('throws when directory has no images', async () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scry-empty-'));
+    fs.writeFileSync(path.join(emptyDir, 'readme.txt'), 'text');
+
+    await expect(runLocalImageProcessing({
+      dir: emptyDir,
+      project: 'test',
+      openaiApiKey: 'sk-test',
+      jinaApiKey: 'jina-test',
+      milvusAddress: 'https://milvus.test',
+      milvusToken: 'tok',
+      milvusCollection: 'col',
+    })).rejects.toThrow('No image files');
+
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  it('runs the full local pipeline end-to-end', async () => {
+    const fetchCalls = [];
+
+    global.fetch = jest.fn(async (url, options) => {
+      fetchCalls.push({ url, method: options?.method || 'GET' });
+
+      // OpenAI vision API
+      if (url === 'https://api.openai.com/v1/chat/completions') {
+        const body = JSON.parse(options.body);
+        const imageCount = body.messages[0].content.filter(c => c.type === 'image_url').length;
+        let components = '';
+        for (let i = 1; i <= imageCount; i++) {
+          components += `<component-${i}>
+            <screen-name>Screen ${i}</screen-name>
+            <description>A test screen ${i}.</description>
+            <tags><tag>Test</tag><tag>UI</tag></tags>
+            <search-queries><query>test screen ${i}</query></search-queries>
+          </component-${i}>`;
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: `<batch-analysis>${components}</batch-analysis>`,
+              },
+            }],
+          }),
+        };
+      }
+
+      // Jina embeddings API
+      if (url === 'https://api.jina.ai/v1/embeddings') {
+        const body = JSON.parse(options.body);
+        const embeddings = body.input.map(() => ({
+          embedding: new Array(1024).fill(0.5),
+        }));
+        return {
+          ok: true,
+          json: async () => ({ data: embeddings }),
+        };
+      }
+
+      // Milvus insert API
+      if (url.includes('/v2/vectordb/entities/insert')) {
+        const body = JSON.parse(options.body);
+        return {
+          ok: true,
+          json: async () => ({
+            code: 0,
+            data: { insertCount: body.data.length },
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const result = await runLocalImageProcessing({
+      dir: tmpDir,
+      project: 'test-project',
+      openaiApiKey: 'sk-test',
+      jinaApiKey: 'jina-test',
+      milvusAddress: 'https://milvus.test',
+      milvusToken: 'tok',
+      milvusCollection: 'my-collection',
+      verbose: false,
+    });
+
+    expect(result.projectId).toBe('test-project');
+    expect(result.totalImages).toBe(2);
+    expect(result.processedImages).toBe(2);
+    expect(result.failedImages).toBe(0);
+    expect(result.status).toBe('completed');
+    expect(result.uploadId).toMatch(/^local-/);
+
+    // Verify API calls happened
+    const openaiCalls = fetchCalls.filter(c => c.url.includes('openai'));
+    const jinaCalls = fetchCalls.filter(c => c.url.includes('jina'));
+    const milvusCalls = fetchCalls.filter(c => c.url.includes('milvus'));
+
+    expect(openaiCalls.length).toBeGreaterThanOrEqual(1);
+    expect(jinaCalls.length).toBeGreaterThanOrEqual(2); // image + text embeddings
+    expect(milvusCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Verify Milvus insert data
+    const milvusCall = fetchCalls.find(c => c.url.includes('milvus'));
+    expect(milvusCall).toBeTruthy();
+  });
+
+  it('includes source_type upload in Milvus records', async () => {
+    let milvusBody = null;
+
+    global.fetch = jest.fn(async (url, options) => {
+      if (url === 'https://api.openai.com/v1/chat/completions') {
+        return {
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: `<batch-analysis>
+                  <component-1><screen-name>Home</screen-name><description>Home screen.</description><tags><tag>Home</tag></tags><search-queries><query>home</query></search-queries></component-1>
+                  <component-2><screen-name>Settings</screen-name><description>Settings screen.</description><tags><tag>Settings</tag></tags><search-queries><query>settings</query></search-queries></component-2>
+                </batch-analysis>`,
+              },
+            }],
+          }),
+        };
+      }
+
+      if (url === 'https://api.jina.ai/v1/embeddings') {
+        const body = JSON.parse(options.body);
+        return {
+          ok: true,
+          json: async () => ({
+            data: body.input.map(() => ({ embedding: new Array(1024).fill(0.1) })),
+          }),
+        };
+      }
+
+      if (url.includes('/v2/vectordb/entities/insert')) {
+        milvusBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          json: async () => ({ code: 0, data: { insertCount: milvusBody.data.length } }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await runLocalImageProcessing({
+      dir: tmpDir,
+      project: 'proj',
+      openaiApiKey: 'sk-test',
+      jinaApiKey: 'jina-test',
+      milvusAddress: 'https://milvus.test',
+      milvusToken: 'tok',
+      milvusCollection: 'col',
+    });
+
+    expect(milvusBody).toBeTruthy();
+    expect(milvusBody.collectionName).toBe('col');
+    expect(milvusBody.data).toHaveLength(2);
+
+    for (const record of milvusBody.data) {
+      expect(record.json_content.source_type).toBe('upload');
+      expect(record.text_embedding).toHaveLength(2048);
+      expect(record.image_embedding).toHaveLength(2048);
+      expect(record.project_id).toBe('proj');
+    }
+
+    expect(milvusBody.data[0].component_name).toBe('Home');
+    expect(milvusBody.data[1].component_name).toBe('Settings');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `upload-images` CLI command with `--dir` and `--project` options
- Add `--local` flag for local processing (LLM vision + embeddings + Milvus insert)
- Queue mode: ZIP → presigned URL → completion signal
- Local mode: OpenAI vision → Jina embeddings → Milvus vector insertion
- Supports env vars: `OPENAI_API_KEY`, `JINA_API_KEY`, `MILVUS_ADDRESS`, `MILVUS_TOKEN`, `MILVUS_COLLECTION`

## Test plan
- [x] `findImageFiles()` — nested dirs, extension filtering, __MACOSX/hidden skip
- [x] `runLocalImageProcessing()` — full pipeline E2E with mocked APIs
- [x] `source_type: 'upload'` in Milvus records verification
- [x] Error on empty directory
- [x] All 8 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)