### PR TITLE
fix: stop reporting indexing the deployer cannot confirm

### DIFF
--- a/.changeset/honest-deploy-reporting.md
+++ b/.changeset/honest-deploy-reporting.md
@@ -1,0 +1,19 @@
+---
+"@scrymore/scry-deployer": minor
+---
+
+Stop reporting indexing the deployer cannot confirm.
+
+Uploading is synchronous; indexing is not. The command printed
+`🎉 Deployment successful! 🎉` immediately after upload, so a build that failed
+in the processing queue seconds later still looked like a success. In one run
+the pipeline died 7s after this message on a revoked credential, and nothing in
+the output said so — the failure only surfaced much later, as an empty search.
+
+The final message is now `✅ Upload complete.`, followed by an explicit note
+that indexing is queued but unverified and that components are not searchable
+until it finishes. If metadata uploaded but was *not* queued, that is called out
+as a warning: the Storybook is hosted, but nothing is being indexed.
+
+Also adds a `warn` level to the logger, which previously had only
+`info`/`success`/`error`/`debug`.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -125,8 +125,29 @@ async function runDeployment(argv) {
 
         await postPRComment(buildDeployResult(argv, coverageSummary, uploadResult), coverageSummary);
 
-        logger.success('\n🎉 Deployment successful! 🎉');
+        // Report only what actually completed. Uploading is synchronous;
+        // indexing is not. A build can fail in the queue seconds after this
+        // point — during one run the pipeline died 7s later on a revoked
+        // credential — and this command previously printed
+        // "Deployment successful" over it, sending people looking for the
+        // cause three steps downstream (ISSUES.md #4).
+        logger.success('\n✅ Upload complete.');
         logUploadLinks(argv, coverageSummary, uploadResult, logger);
+
+        if (uploadResult?.metadataUpload?.queued) {
+            logger.info(
+                '\n⏳ Indexing has been queued, not finished.\n' +
+                '   This command cannot confirm it succeeded. Components will not be\n' +
+                '   searchable until processing completes, and a failed build reports\n' +
+                '   nothing here. Before relying on search, confirm the build shows\n' +
+                "   processingStatus 'completed' rather than 'failed'."
+            );
+        } else if (uploadResult?.metadataUpload) {
+            logger.warn(
+                '\n⚠️  Metadata was uploaded but not queued for processing.\n' +
+                '   The Storybook is hosted, but its components are NOT being indexed.'
+            );
+        }
 
     } finally {
         // 4. Clean up the local archive

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
  * The logger's behavior is controlled by the arguments passed to the CLI.
  * @param {object} argv The arguments object from yargs.
  * @param {boolean} argv.verbose Whether to enable verbose (debug) logging.
- * @returns {{info: Function, error: Function, debug: Function, success: Function}}
+ * @returns {{info: Function, warn: Function, error: Function, debug: Function, success: Function}}
  */
 function createLogger({ verbose = false }) {
   const Sentry = require('@sentry/node');
@@ -29,6 +29,21 @@ function createLogger({ verbose = false }) {
      */
     success: (message) => {
       console.log(chalk.green(message));
+    },
+
+    /**
+     * Logs a warning: something the operator must act on, but which did not
+     * fail the command. Distinct from error() so it does not read as a failed
+     * deployment.
+     * @param {string} message The message to log.
+     */
+    warn: (message) => {
+      console.warn(chalk.yellow(message));
+      Sentry.addBreadcrumb({
+        category: 'log',
+        message: message,
+        level: 'warning',
+      });
     },
 
     /**

--- a/test/cli-deployment.test.js
+++ b/test/cli-deployment.test.js
@@ -8,6 +8,86 @@ describe('bin/cli runDeployment()', () => {
     jest.restoreAllMocks();
   });
 
+  // ISSUES.md #4. Uploading is synchronous; indexing is not. This command used
+  // to print "Deployment successful" and stop, so a build that died in the queue
+  // seconds later looked like a success and sent people debugging three steps
+  // downstream. These assert it no longer overclaims.
+  describe('does not report indexing it cannot confirm', () => {
+    function mockDeps(uploadBuild) {
+      jest.doMock('../lib/apiClient.js', () => ({
+        getApiClient: jest.fn(() => ({ defaults: { baseURL: 'x' } })),
+        uploadBuild,
+      }));
+      jest.doMock('../lib/archive.js', () => ({
+        zipDirectory: jest.fn(async (_dir, outPath) => {
+          fs.writeFileSync(outPath, 'zip');
+        }),
+      }));
+      jest.doMock('../lib/pr-comment.js', () => ({ postPRComment: jest.fn(async () => {}) }));
+    }
+
+    const baseArgs = {
+      dir: './test-storybook-static',
+      project: 'p',
+      version: 'v',
+      apiUrl: 'https://example.invalid',
+      apiKey: 'k',
+      withAnalysis: false,
+      coverage: false,
+      verbose: false,
+    };
+
+    test('says indexing is queued but unconfirmed, and never claims success', async () => {
+      mockDeps(jest.fn().mockResolvedValue({
+        zipUpload: { success: true },
+        coverageUpload: null,
+        metadataUpload: { success: true, queued: true, buildNumber: 7 },
+      }));
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      const { runDeployment } = require('../bin/cli.js');
+      await runDeployment({ ...baseArgs });
+
+      const out = log.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(out).toContain('Upload complete');
+      expect(out).toContain('queued, not finished');
+      expect(out).not.toContain('Deployment successful');
+    });
+
+    test('warns loudly when metadata uploaded but was not queued', async () => {
+      mockDeps(jest.fn().mockResolvedValue({
+        zipUpload: { success: true },
+        coverageUpload: null,
+        metadataUpload: { success: true, queued: false },
+      }));
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { runDeployment } = require('../bin/cli.js');
+      await runDeployment({ ...baseArgs });
+
+      const out = warn.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(out).toContain('NOT being indexed');
+    });
+
+    test('stays quiet about indexing when no metadata was uploaded', async () => {
+      mockDeps(jest.fn().mockResolvedValue({
+        zipUpload: { success: true },
+        coverageUpload: null,
+        metadataUpload: null,
+      }));
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { runDeployment } = require('../bin/cli.js');
+      await runDeployment({ ...baseArgs });
+
+      const out = [...log.mock.calls, ...warn.mock.calls].map((c) => String(c[0])).join('\n');
+      expect(out).toContain('Upload complete');
+      expect(out).not.toContain('queued, not finished');
+      expect(out).not.toContain('NOT being indexed');
+    });
+  });
+
   test('deploys without analysis and with coverage disabled', async () => {
     const uploadBuild = jest.fn().mockResolvedValue({ zipUpload: { success: true }, coverageUpload: null });
 


### PR DESCRIPTION
## The problem

Uploading is synchronous; indexing is not. The command printed this immediately after upload:

```
🎉 Deployment successful! 🎉
```

So a build that failed in the processing queue seconds later still looked like a success.

During one run the pipeline died **7 seconds after this message** on a revoked OpenAI credential. Nothing in the output said so. The failure surfaced much later as an empty search, and finding the cause took a Workers Logs query — three steps downstream of where it actually broke.

This is [ISSUES.md #4](https://github.com/epinnock/scry-management/blob/main/ISSUES.md), and it is the single biggest reason the August run took hours instead of minutes: **every failure surfaced somewhere other than where it happened.**

## Change

The closing message is now `✅ Upload complete.` — which is true — followed by an explicit note that indexing is queued but unverified and components are not searchable until it finishes.

If metadata uploaded but was **not** queued, that is called out as a warning: the Storybook is hosted, but nothing is being indexed. Previously indistinguishable from full success.

## Why not poll for the real status

Polling for the terminal state would be better, but the upload service has **no build-status endpoint** today — adding one is a separate change to a separate service. Not overclaiming is the part that can ship now; the runbook documents the manual check.

## Also

Adds a `warn` level to the logger, which had only `info`/`success`/`error`/`debug`. The new not-queued branch called `logger.warn` and would have **thrown at runtime** — a crash reachable only on the rare path, which is exactly the sort that ships unnoticed.

## Verification

**49/49 tests.** Three new, covering each outcome: queued, uploaded-but-not-queued, and no metadata at all — including that the string "Deployment successful" no longer appears.

Changeset included (`minor`), so this releases through the normal changesets flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrHWvMjdm185tW295VCs31