### PR TITLE
fix: retry the deploy upload on transient network failures

### DIFF
--- a/.changeset/upload-retry-on-transient-failure.md
+++ b/.changeset/upload-retry-on-transient-failure.md
@@ -1,0 +1,17 @@
+---
+"@scrymore/scry-deployer": patch
+---
+
+Retry the deploy upload on transient network failures.
+
+The presigned-URL request and the R2 upload were both single-shot, so a momentary
+DNS hiccup or connection reset discarded the several minutes of screenshot capture
+that had already succeeded. Six consecutive real deploys failed this way in one
+afternoon, each with `EAI_AGAIN` or `ECONNRESET` at the final step.
+
+Both calls now retry up to four times with exponential backoff, and only on
+conditions a later attempt can survive (network-level errors, 429, and 5xx) —
+a 4xx still fails immediately rather than delaying the error the user needs to
+see. Each retry re-requests the presigned URL, since those are signed at request
+time and would otherwise expire into a confusing signature error. Retries are
+logged at info level so a recovering deploy is not mistaken for a hung one.

--- a/lib/apiClient.js
+++ b/lib/apiClient.js
@@ -16,8 +16,81 @@ const logger = createLogger({ verbose: isVerbose });
 const COVERAGE_UPLOAD_DELAY_MS = 5000;
 const COVERAGE_RETRY_DELAY_MS = 60000;
 
+// The upload is the last step of a deploy, so a blip here discards several
+// minutes of completed screenshot capture. Retrying is far cheaper than
+// redoing that work. See ISSUES.md #19.
+const UPLOAD_MAX_ATTEMPTS = 4;
+const UPLOAD_BACKOFF_BASE_MS = 2000;
+
+// Network-level failures that a later attempt can plausibly survive. Flapping
+// DNS reports EAI_AGAIN (and, mid-flap, ENOTFOUND) rather than a clean refusal.
+const TRANSIENT_CODES = new Set([
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ECONNABORTED',
+  'EPIPE',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ERR_NETWORK',
+]);
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Whether a failed upload attempt is worth repeating.
+ *
+ * A 4xx other than 429 means the request itself is wrong — retrying it just
+ * burns time and produces the identical failure.
+ *
+ * @param {Error & {code?: string, response?: {status?: number}}} error
+ * @returns {boolean}
+ */
+function isTransientUploadError(error) {
+  const status = error?.response?.status;
+  if (typeof status === 'number') {
+    return status === 429 || status >= 500;
+  }
+  return TRANSIENT_CODES.has(error?.code);
+}
+
+/**
+ * Run an upload attempt, repeating it while the failure looks transient.
+ *
+ * @template T
+ * @param {(attempt: number) => Promise<T>} attemptFn
+ * @param {string} label Shown in logs so a retried upload does not look like a hang.
+ * @returns {Promise<T>}
+ */
+async function withUploadRetry(attemptFn, label) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= UPLOAD_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await attemptFn(attempt);
+    } catch (error) {
+      lastError = error;
+
+      if (!isTransientUploadError(error) || attempt === UPLOAD_MAX_ATTEMPTS) {
+        throw error;
+      }
+
+      const backoff = UPLOAD_BACKOFF_BASE_MS * Math.pow(2, attempt - 1);
+      const reason = error.code || `HTTP ${error?.response?.status}`;
+      // Deliberately at info level: a silent retry is indistinguishable from a
+      // hung deploy, which is its own reported failure mode.
+      logger.info(
+        `${label} attempt ${attempt}/${UPLOAD_MAX_ATTEMPTS} failed (${reason}); retrying in ${backoff / 1000}s...`
+      );
+      await sleep(backoff);
+    }
+  }
+
+  throw lastError;
 }
 
 /**
@@ -205,9 +278,14 @@ async function uploadFileDirectly(apiClient, { project, version }, filePath, fil
   const contentType = file.contentType || 'application/zip';
 
   try {
-    const presigned = await requestPresignedUrl(apiClient, { project, version }, { fileName, contentType });
-    const upload = await putToPresignedUrl(presigned.url, fileBuffer, contentType);
-    return { success: true, url: presigned.url, status: upload.status, visibility: presigned.visibility };
+    // The presigned URL is signed at request time, so a retry after a long
+    // backoff must re-request it — reusing a stale one fails with a confusing
+    // signature error instead of the real network cause.
+    return await withUploadRetry(async () => {
+      const presigned = await requestPresignedUrl(apiClient, { project, version }, { fileName, contentType });
+      const upload = await putToPresignedUrl(presigned.url, fileBuffer, contentType);
+      return { success: true, url: presigned.url, status: upload.status, visibility: presigned.visibility };
+    }, `Upload of ${fileName}`);
   } catch (error) {
     logger.debug(`Upload failed. Error type: ${error.constructor.name}, Message: ${error.message}`);
     const details = getAxiosErrorDetails(error, apiClient.defaults.baseURL);
@@ -374,4 +452,7 @@ module.exports = {
   uploadBuild,
   requestPresignedUrl,
   putToPresignedUrl,
+  isTransientUploadError,
+  withUploadRetry,
+  UPLOAD_MAX_ATTEMPTS,
 };

--- a/test/uploadRetry.test.js
+++ b/test/uploadRetry.test.js
@@ -1,0 +1,125 @@
+const {
+  isTransientUploadError,
+  withUploadRetry,
+  UPLOAD_MAX_ATTEMPTS,
+} = require('../lib/apiClient.js');
+
+/**
+ * ISSUES.md #19. The upload is the last step of a deploy, so a one-second blip
+ * used to discard the ~156s of screenshot capture that had already succeeded.
+ * Six consecutive real deploys failed this way on 2026-08-06, every one a
+ * single-shot network error.
+ */
+describe('isTransientUploadError', () => {
+  it.each(['EAI_AGAIN', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE', 'ENOTFOUND'])(
+    'treats %s as worth retrying',
+    (code) => {
+      expect(isTransientUploadError(Object.assign(new Error('net'), { code }))).toBe(true);
+    }
+  );
+
+  it.each([500, 502, 503, 429])('treats HTTP %i as worth retrying', (status) => {
+    expect(isTransientUploadError({ response: { status } })).toBe(true);
+  });
+
+  // A malformed or unauthorised request fails identically on every attempt;
+  // retrying only delays the error the user needs to see.
+  it.each([400, 401, 403, 404])('treats HTTP %i as terminal', (status) => {
+    expect(isTransientUploadError({ response: { status } })).toBe(false);
+  });
+
+  it('does not retry an unrecognised failure', () => {
+    expect(isTransientUploadError(new TypeError('bad argument'))).toBe(false);
+  });
+
+  // An HTTP response takes precedence over any code on the error object —
+  // axios sets both, and the status is the more specific signal.
+  it('prefers the HTTP status over the error code', () => {
+    const err = Object.assign(new Error('boom'), {
+      code: 'ECONNRESET',
+      response: { status: 403 },
+    });
+    expect(isTransientUploadError(err)).toBe(false);
+  });
+});
+
+describe('withUploadRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** Runs fn to completion while auto-advancing the backoff timers. */
+  async function runWithTimers(fn) {
+    const promise = fn();
+    const settled = promise.then(
+      (v) => ({ ok: true, v }),
+      (e) => ({ ok: false, e })
+    );
+    // Each pass releases one pending backoff.
+    for (let i = 0; i < UPLOAD_MAX_ATTEMPTS + 1; i++) {
+      await Promise.resolve();
+      jest.runOnlyPendingTimers();
+    }
+    return settled;
+  }
+
+  it('returns the value without retrying when the first attempt works', async () => {
+    const attempt = jest.fn().mockResolvedValue('done');
+    const result = await runWithTimers(() => withUploadRetry(attempt, 'Upload'));
+
+    expect(result).toEqual({ ok: true, v: 'done' });
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers when a transient failure is followed by success', async () => {
+    const attempt = jest
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('dns'), { code: 'EAI_AGAIN' }))
+      .mockResolvedValue('done');
+
+    const result = await runWithTimers(() => withUploadRetry(attempt, 'Upload'));
+
+    expect(result).toEqual({ ok: true, v: 'done' });
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  // The whole point of re-running the closure rather than just the PUT: the
+  // presigned URL is signed at request time and would be stale after a backoff.
+  it('re-runs the entire attempt so the presigned URL is refreshed', async () => {
+    const urls = [];
+    const attempt = jest.fn(async (n) => {
+      urls.push(`signed-url-${n}`);
+      if (n < 3) throw Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+      return 'done';
+    });
+
+    await runWithTimers(() => withUploadRetry(attempt, 'Upload'));
+
+    expect(urls).toEqual(['signed-url-1', 'signed-url-2', 'signed-url-3']);
+  });
+
+  it('gives up after the attempt cap and surfaces the last error', async () => {
+    const attempt = jest
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('dns'), { code: 'EAI_AGAIN' }));
+
+    const result = await runWithTimers(() => withUploadRetry(attempt, 'Upload'));
+
+    expect(result.ok).toBe(false);
+    expect(result.e.code).toBe('EAI_AGAIN');
+    expect(attempt).toHaveBeenCalledTimes(UPLOAD_MAX_ATTEMPTS);
+  });
+
+  it('fails immediately on a terminal error rather than burning attempts', async () => {
+    const attempt = jest.fn().mockRejectedValue({ response: { status: 401 } });
+
+    const result = await runWithTimers(() => withUploadRetry(attempt, 'Upload'));
+
+    expect(result.ok).toBe(false);
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Why

The upload is the **last** step of a deploy, and it had no retry at all. Both the presigned-URL request and the R2 PUT were single-shot, so a one-second network blip discarded the ~156s of screenshot capture that had already succeeded — and nothing is resumable, so recovery meant redoing all of it.

This is not hypothetical. Six consecutive real deploys failed this way in a single afternoon while re-running the demo runbook's three-consecutive-passes gate:

| run | failing call | code |
|---|---|---|
| v1.7.1 | presigned-URL POST | `EAI_AGAIN` |
| v1.7.2 | R2 PUT | `EAI_AGAIN` |
| v1.7.3 | R2 PUT | `ECONNRESET` |
| v1.7.4 | R2 PUT | `EAI_AGAIN` |
| v1.8.0 | R2 PUT | `EAI_AGAIN` |
| v1.8.1 | presigned-URL POST | `EAI_AGAIN` |

The outage behind those was environmental, but the *response* to it is the defect. A customer running this in CI hits the same class of blip on a normal week and sees a red build reading `No response received` after three minutes of apparently healthy progress.

`lib/localImageProcessing.js` has had exponential backoff and 429 handling all along — the upload path just never got the same treatment.

## What changed

`isTransientUploadError` + `withUploadRetry` in `lib/apiClient.js`, wrapping the presigned request and the PUT as a single retryable unit: 4 attempts, 2s doubling backoff.

Two details that are easy to get wrong:

- **The whole attempt re-runs, not just the PUT.** Presigned URLs are signed at request time, so retrying a stale one after a backoff fails with a confusing signature error instead of the real network cause.
- **Retries log at info level.** A silent retry is indistinguishable from a hung deploy — which is its own separately-reported failure mode.

Only transient conditions retry (network-level codes, 429, 5xx). A 4xx fails immediately rather than delaying the error the user actually needs to see; an HTTP status takes precedence over any `code` on the error object, since axios sets both.

## Testing

20 new tests in `test/uploadRetry.test.js` covering the retry/terminal split, the attempt cap, and that each attempt re-requests the URL. Full suite: **69/69 green**.

**One caveat worth stating plainly:** the three demo runs that passed after this change triggered zero retries, because the network had recovered by then. The unit tests prove the logic; this has not yet been observed rescuing a real deploy.

Refs `ISSUES.md` #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)