### PR TITLE
fix: stop sending credentials to error reporting

### DIFF
--- a/.changeset/cli-telemetry-scrubbing.md
+++ b/.changeset/cli-telemetry-scrubbing.md
@@ -1,0 +1,26 @@
+---
+"@scrymore/scry-deployer": patch
+---
+
+Stop sending credentials to error reporting, and document the reporting.
+
+The CLI already reported errors to Sentry, and it was sending three things it
+should not have. `scope.setExtra('argv', argv)` shipped the whole parsed argv,
+which contains `--api-key` under both `apiKey` and `api-key` — so every failed
+deploy carried the customer's project credential to a third party. Upload errors
+quote the presigned URL in full, including `X-Amz-Signature`, which is a
+time-limited write credential for the bucket. Stack frames carried absolute paths
+containing usernames and, often, unreleased product names.
+
+Reporting now uses an allowlist of argv fields rather than the whole object, so a
+newly added option is invisible to telemetry until someone opts it in — the
+reverse, remembering to exclude each new secret, is exactly how the API key got
+through. Messages, exception values and extras are scrubbed for presigned query
+strings, `scry_proj_` keys and bearer tokens, and stack frames are reduced to
+basenames.
+
+Adds an opt-out. `SCRY_TELEMETRY=0` and the cross-tool `DO_NOT_TRACK=1` are both
+honoured, including in CI. The README now documents what is and is not sent;
+previously nothing disclosed that the CLI reported at all.
+
+Traces are no longer sampled from customer machines — errors only.

--- a/README.md
+++ b/README.md
@@ -835,6 +835,31 @@ Then update the `if` condition in the notification steps:
 
 ---
 
+## 📊 Error Reporting
+
+When a deploy fails, this CLI reports the error to Scry so we can fix it. It runs on
+your machine, so it is worth being precise about what leaves it.
+
+**Sent:** the error and its stack trace, the CLI and Node versions, the platform, and
+the project id, deploy version, branch and whether analysis was enabled.
+
+**Not sent:** your API key, presigned upload URLs and their signatures, absolute file
+paths, your hostname or username, your component names, and your source code. Stack
+frames are reduced to file basenames, and anything resembling a credential is redacted
+before the report is sent — including the signed URLs that upload errors would
+otherwise quote in full.
+
+Nothing is reported on a successful run.
+
+**To opt out**, set either variable:
+
+```bash
+export SCRY_TELEMETRY=0     # Scry-specific
+export DO_NOT_TRACK=1       # respected across many CLI tools
+```
+
+Both are honoured everywhere, including CI.
+
 ## 🔧 Troubleshooting the Init Command
 
 ### Command fails with "Not a git repository"

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const Sentry = require('@sentry/node');
+const { initTelemetry, captureCliError, flushTelemetry } = require('../lib/telemetry.js');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 const fs = require('fs');
@@ -166,21 +166,12 @@ async function handleError(error, argv) {
     const logger = createLogger(argv || {});
     logger.error(`\n❌ Error: ${error.message}`);
 
-    // Capture error in Sentry with additional context
-    Sentry.withScope((scope) => {
-        if (argv) {
-            scope.setTags({
-                project: argv.project,
-                version: argv.version,
-                command: argv._ ? argv._[0] : 'unknown',
-            });
-            scope.setExtra('argv', argv);
-        }
-        Sentry.captureException(error);
-    });
-    
+    // Report with an allowlisted subset of argv. Sending argv wholesale shipped
+    // the customer's --api-key to Sentry on every error.
+    captureCliError(error, argv);
+
     // Ensure the event is sent before the process exits
-    await Sentry.close(2000);
+    await flushTelemetry(2000);
 
     if (error instanceof ApiError) {
         if (error.statusCode === 401) {
@@ -198,12 +189,9 @@ async function handleError(error, argv) {
 }
 
 async function main() {
-    // Initialize Sentry
-    Sentry.init({
-        dsn: "https://c66ce229a1db2289f145eebd02436d9c@o4507889391828992.ingest.us.sentry.io/4510699330732032", // Fallback to hardcoded DSN for user reporting
-        tracesSampleRate: 1.0,
-        environment: process.env.NODE_ENV || 'production',
-    });
+    // Error reporting. Opt out with SCRY_TELEMETRY=0 or DO_NOT_TRACK=1.
+    // Configuration and scrubbing live in lib/telemetry.js.
+    initTelemetry();
 
     try {
         const args = await yargs(hideBin(process.argv))

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -1,0 +1,140 @@
+const Sentry = require('@sentry/node');
+
+/**
+ * Error reporting for a CLI that runs on other people's machines.
+ *
+ * This is not a server. Everything it sends left a customer's laptop or CI
+ * runner, so the default has to be "send the minimum that makes a crash
+ * diagnosable", not "send the context and sort it out later".
+ *
+ * Three things were being sent that should not have been:
+ *
+ *   1. `scope.setExtra('argv', argv)` shipped the whole parsed argv — which
+ *      contains `--api-key` under both `apiKey` and `api-key`. Every customer
+ *      error carried their project credential to a third party.
+ *   2. Upload failures embed the presigned URL in the message, query string and
+ *      all: `...storybook.zip?X-Amz-Signature=645e57...`. That signature is a
+ *      time-limited write credential for the bucket.
+ *   3. Absolute paths (`/home/alice/work/app`) leak usernames and, often,
+ *      unreleased product names.
+ *
+ * None of that is needed to know that an upload failed with EAI_AGAIN.
+ */
+
+const DSN =
+  'https://c66ce229a1db2289f145eebd02436d9c@o4507889391828992.ingest.us.sentry.io/4510699330732032';
+
+/**
+ * argv fields safe to attach to an error.
+ *
+ * An allowlist, not a denylist: a new option should be invisible to telemetry
+ * until someone deliberately adds it here. The reverse — remembering to exclude
+ * each new secret — is the failure mode that put an API key in Sentry.
+ */
+const SAFE_ARGV_FIELDS = ['project', 'deployVersion', 'withAnalysis', 'verbose', 'branch'];
+
+/** Anything that looks like a credential, wherever it appears in a string. */
+const SECRET_PATTERNS = [
+  // Presigned URL query strings. Keep the path so the failing operation is
+  // still identifiable; drop the signature and everything with it.
+  [/(https?:\/\/[^\s?]+)\?[^\s]*/g, '$1?<redacted>'],
+  [/scry_proj_[A-Za-z0-9_\-]+/g, 'scry_proj_<redacted>'],
+  [/(X-Amz-Signature=)[^&\s]+/gi, '$1<redacted>'],
+  [/(Bearer\s+)[A-Za-z0-9._\-]+/gi, '$1<redacted>'],
+];
+
+function scrub(value) {
+  if (typeof value !== 'string') return value;
+  return SECRET_PATTERNS.reduce((acc, [pattern, replacement]) => acc.replace(pattern, replacement), value);
+}
+
+/**
+ * Whether the user has asked not to be tracked.
+ *
+ * DO_NOT_TRACK is honoured as well as our own flag — it is the cross-tool
+ * convention (consoledonottrack.com), and a developer who has set it globally
+ * should not have to discover a Scry-specific variable to be heard.
+ */
+function telemetryDisabled() {
+  const off = (v) => v === '1' || v === 'true' || v === 'yes';
+  return off(process.env.DO_NOT_TRACK) || process.env.SCRY_TELEMETRY === '0' ||
+    process.env.SCRY_TELEMETRY === 'false';
+}
+
+/** Only the fields on the allowlist, and scrubbed even then. */
+function sanitizeArgv(argv) {
+  if (!argv) return {};
+  const safe = {};
+  for (const field of SAFE_ARGV_FIELDS) {
+    if (argv[field] !== undefined) safe[field] = scrub(argv[field]);
+  }
+  return safe;
+}
+
+function initTelemetry() {
+  if (telemetryDisabled()) return false;
+
+  Sentry.init({
+    dsn: DSN,
+    environment: process.env.NODE_ENV || 'production',
+
+    // Errors only. Traces from a CLI describe the customer's build pipeline,
+    // which is more than is needed to fix a crash.
+    tracesSampleRate: 0,
+
+    // No usernames, IPs, or machine hostnames.
+    sendDefaultPii: false,
+    serverName: false,
+
+    beforeSend(event) {
+      if (event.message) event.message = scrub(event.message);
+
+      for (const entry of event.exception?.values ?? []) {
+        if (entry.value) entry.value = scrub(entry.value);
+        // Stack frames carry absolute paths from the customer's disk. The
+        // filename is what makes a trace useful, so keep the basename only.
+        for (const frame of entry.stacktrace?.frames ?? []) {
+          if (frame.filename) frame.filename = frame.filename.replace(/^.*[\\/]/, '');
+          delete frame.abs_path;
+        }
+      }
+
+      // Belt and braces: whatever else ends up in extra, scrub its strings.
+      if (event.extra) {
+        for (const [k, v] of Object.entries(event.extra)) event.extra[k] = scrub(v);
+      }
+
+      return event;
+    },
+  });
+
+  return true;
+}
+
+/** Report an error with only the context that is safe to leave the machine. */
+function captureCliError(error, argv) {
+  if (telemetryDisabled()) return;
+
+  Sentry.withScope((scope) => {
+    const safe = sanitizeArgv(argv);
+    if (safe.project) scope.setTag('project', safe.project);
+    if (argv && argv._) scope.setTag('command', argv._[0] || 'deploy');
+    scope.setExtra('options', safe);
+    Sentry.captureException(error);
+  });
+}
+
+async function flushTelemetry(ms = 2000) {
+  if (telemetryDisabled()) return;
+  await Sentry.close(ms);
+}
+
+module.exports = {
+  initTelemetry,
+  captureCliError,
+  flushTelemetry,
+  telemetryDisabled,
+  sanitizeArgv,
+  scrub,
+  SAFE_ARGV_FIELDS,
+};

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -1,0 +1,120 @@
+const {
+  scrub,
+  sanitizeArgv,
+  telemetryDisabled,
+  SAFE_ARGV_FIELDS,
+} = require('../lib/telemetry.js');
+
+/**
+ * This CLI runs on customers' machines, so every field it reports left someone
+ * else's laptop or CI runner. Three things were being sent that should not
+ * have been, and these tests exist to keep them out.
+ */
+describe('scrub', () => {
+  // The upload error message embeds the presigned URL in full. That query
+  // string is a time-limited write credential for the bucket.
+  it('removes the signature from a presigned URL but keeps the path', () => {
+    const message =
+      'No response received from https://bucket.r2.cloudflarestorage.com/p/v/storybook.zip' +
+      '?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=645e571c8c169bf1&X-Amz-Expires=3600 (EAI_AGAIN)';
+
+    const out = scrub(message);
+
+    expect(out).not.toContain('645e571c8c169bf1');
+    expect(out).not.toContain('X-Amz-Algorithm');
+    // Still identifies which object failed, which is the diagnostic value.
+    expect(out).toContain('storybook.zip');
+    expect(out).toContain('<redacted>');
+  });
+
+  it('removes a project API key wherever it appears', () => {
+    expect(scrub('key scry_proj_U9m2H2yeC9wFiR4hlMta_abc-123 rejected'))
+      .toBe('key scry_proj_<redacted> rejected');
+  });
+
+  it('removes bearer tokens', () => {
+    expect(scrub('Authorization: Bearer eyJhbGciOi.J9.xyz')).toContain('Bearer <redacted>');
+  });
+
+  it('leaves ordinary messages untouched', () => {
+    const plain = 'Failed to upload file: connection reset (ECONNRESET)';
+    expect(scrub(plain)).toBe(plain);
+  });
+
+  it('passes through non-strings rather than throwing', () => {
+    expect(scrub(undefined)).toBeUndefined();
+    expect(scrub(42)).toBe(42);
+  });
+});
+
+describe('sanitizeArgv', () => {
+  const argv = {
+    _: ['deploy'],
+    project: 'U9m2H2yeC9wFiR4hlMta',
+    apiKey: 'scry_proj_SECRET',
+    'api-key': 'scry_proj_SECRET',
+    dir: '/home/alice/work/unreleased-product',
+    deployVersion: 'v1.2.3',
+    apiUrl: 'https://upload.example.com',
+  };
+
+  // The bug this whole module exists for: setExtra('argv', argv) sent the key.
+  it('never includes the API key, under either spelling', () => {
+    const safe = sanitizeArgv(argv);
+    expect(safe.apiKey).toBeUndefined();
+    expect(safe['api-key']).toBeUndefined();
+    expect(JSON.stringify(safe)).not.toContain('SECRET');
+  });
+
+  // Absolute paths carry the developer's username and often the name of an
+  // unannounced product.
+  it('never includes local filesystem paths', () => {
+    const safe = sanitizeArgv(argv);
+    expect(safe.dir).toBeUndefined();
+    expect(JSON.stringify(safe)).not.toContain('/home/alice');
+  });
+
+  it('keeps the fields that make an error diagnosable', () => {
+    const safe = sanitizeArgv(argv);
+    expect(safe.project).toBe('U9m2H2yeC9wFiR4hlMta');
+    expect(safe.deployVersion).toBe('v1.2.3');
+  });
+
+  // An allowlist means a newly added option is invisible until someone opts it
+  // in. A denylist would require remembering to exclude each new secret, which
+  // is precisely how the API key got through.
+  it('excludes anything not explicitly allowlisted', () => {
+    const safe = sanitizeArgv({ ...argv, someNewSecretOption: 'oops' });
+    expect(safe.someNewSecretOption).toBeUndefined();
+    expect(Object.keys(safe).every((k) => SAFE_ARGV_FIELDS.includes(k))).toBe(true);
+  });
+
+  it('handles a missing argv', () => {
+    expect(sanitizeArgv(undefined)).toEqual({});
+  });
+});
+
+describe('telemetryDisabled', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('is off by default', () => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.SCRY_TELEMETRY;
+    expect(telemetryDisabled()).toBe(false);
+  });
+
+  it('honours SCRY_TELEMETRY=0', () => {
+    process.env.SCRY_TELEMETRY = '0';
+    expect(telemetryDisabled()).toBe(true);
+  });
+
+  // The cross-tool convention. Someone who sets it globally should not have to
+  // find a Scry-specific variable to be heard.
+  it('honours DO_NOT_TRACK=1', () => {
+    process.env.DO_NOT_TRACK = '1';
+    expect(telemetryDisabled()).toBe(true);
+  });
+});


### PR DESCRIPTION
## What I found

The CLI **already reported errors to Sentry** — so this is a review, not an addition. It was sending three things it should not have, and it runs on customers' machines, so each one left someone else's laptop or CI runner.

**1. The customer's API key.** `scope.setExtra('argv', argv)` shipped the whole parsed argv, and argv contains `--api-key` under *both* `apiKey` and `api-key`. Verified:

```
argv keys: _, api-key, apiKey, project, dir
argv.apiKey present: "scry_proj_SECRET123"
```

Every failed deploy carried a project credential to a third party.

**2. Presigned upload URLs, signature included.** Upload failures quote the URL in full — `...storybook.zip?X-Amz-Algorithm=...&X-Amz-Signature=645e571c8c...`. That signature is a time-limited **write credential for the bucket**. The retry work added earlier makes those messages more common, not less.

**3. Absolute paths.** Stack frames carried `/home/alice/work/unreleased-product` — usernames, and often the name of something unannounced.

## The fix

**Allowlist, not denylist.** Reporting now sends only `project`, `deployVersion`, `withAnalysis`, `verbose`, `branch`. The direction matters: a newly added option is invisible to telemetry until someone opts it in, whereas a denylist needs someone to remember to exclude each new secret — which is exactly how the API key got through.

**Scrubbing** of messages, exception values and extras for presigned query strings, `scry_proj_` keys and bearer tokens. The object path survives, so a failure is still identifiable:

```
.../storybook.zip?<redacted> (EAI_AGAIN)
```

**Stack frames reduced to basenames**, `abs_path` dropped, `sendDefaultPii: false`, `serverName: false`.

**An opt-out, which did not exist.** `SCRY_TELEMETRY=0` and the cross-tool `DO_NOT_TRACK=1`, both honoured everywhere including CI.

**Disclosure.** The README now documents what is and is not sent. Previously nothing said the CLI reported at all.

Traces are no longer sampled from customer machines — errors only.

## Testing

13 new tests covering each leak specifically, plus the allowlist direction. Suite **82/82**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)