### PR TITLE
fix: stop committing the API key to the repo (#23)

### DIFF
--- a/.changeset/no-api-key-in-committed-config.md
+++ b/.changeset/no-api-key-in-committed-config.md
@@ -1,0 +1,20 @@
+---
+"@scrymore/scry-deployer": minor
+---
+
+`scry init` no longer writes your API key into the committed config file.
+
+`--commit-api-key` described itself as "not recommended" and defaulted to true, so
+every `init` wrote the key into `.storybook-deployer.json` and committed it. The
+copy was never load-bearing: `init` already stores the key as the `SCRY_API_KEY`
+GitHub secret and the workflow it generates reads it from there.
+
+Passing `--no-commit-api-key` did not help either — the key was written regardless,
+and the `.gitignore` entry it added never matched, because `#` only starts a comment
+at the beginning of a line in `.gitignore`.
+
+The default is now false and the escape hatch still exists behind an explicit
+`--commit-api-key`. For local runs, export `SCRY_API_KEY` instead.
+
+**If you ran an earlier version, rotate that project's API key** — git history keeps
+it after the file is changed.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -409,9 +409,13 @@ async function main() {
                         alias: 'skipGhSetup'
                     })
                     .option('commit-api-key', {
-                        describe: 'Commit API key in config file (not recommended)',
+                        describe: 'Write the API key into the committed config file (not recommended)',
                         type: 'boolean',
-                        default: true,
+                        // False by default. The description has always said "not
+                        // recommended" while the default said otherwise, and the
+                        // default won: every `init` wrote a customer's key into a
+                        // file it then committed.
+                        default: false,
                         alias: 'commitApiKey'
                     })
                     .option('verbose', {

--- a/lib/init.js
+++ b/lib/init.js
@@ -47,19 +47,27 @@ async function runInit(argv) {
         // Step 3: Create config file
         const step3Start = Date.now();
         logger.info('3/8: Creating configuration file...');
-        createConfigFile(argv.project, argv.apiKey, argv.apiUrl, envInfo);
+        createConfigFile(argv.project, argv.apiKey, argv.apiUrl, envInfo, argv.commitApiKey);
         const step3Duration = Date.now() - step3Start;
         logger.success(`✅ Created .storybook-deployer.json [${step3Duration}ms]\n`);
 
-        // Step 4: Add to gitignore (optional - keep API key out of git if user prefers)
+        // Step 4: Report what the committed config does and does not contain.
+        //
+        // This step used to add `.storybook-deployer.json` to .gitignore, which was
+        // wrong in both directions. The config now holds no credential, so ignoring
+        // it would only stop a team sharing its project id — and the entry it wrote,
+        // `.storybook-deployer.json  # Contains API key`, never matched anything:
+        // in .gitignore a `#` is only a comment at the start of a line, so the
+        // pattern included the trailing text and git ignored no file.
         const step4Start = Date.now();
-        if (!argv.commitApiKey) {
-            logger.info('4/8: Updating .gitignore...');
-            updateGitignore();
-            const step4Duration = Date.now() - step4Start;
-            logger.success(`✅ Updated .gitignore (API key will use env vars in CI) [${step4Duration}ms]\n`);
+        if (argv.commitApiKey) {
+            logger.info('4/8: Checking credentials...');
+            logger.error(`⚠️  --commit-api-key: your API key will be written to .storybook-deployer.json and committed.
+   Git history keeps it after rotation, and CI does not need it — the key is
+   already stored as the SCRY_API_KEY repository secret. [${Date.now() - step4Start}ms]\n`);
         } else {
-            logger.info('4/8: Skipping .gitignore update (--commit-api-key flag set)\n');
+            logger.info('4/8: Checking credentials...');
+            logger.success(`✅ .storybook-deployer.json holds no credentials — safe to commit [${Date.now() - step4Start}ms]\n`);
         }
 
         // Step 5: Generate workflow files
@@ -94,7 +102,7 @@ async function runInit(argv) {
         // Step 7: Git commit
         const step7Start = Date.now();
         logger.info('7/8: Committing changes...');
-        const commitResult = gitCommit(argv.commitApiKey, logger);
+        const commitResult = gitCommit(logger);
         const step7Duration = Date.now() - step7Start;
         if (commitResult.success) {
             logger.success(`✅ Changes committed: ${commitResult.sha} [${step7Duration}ms]\n`);
@@ -236,7 +244,7 @@ function parseGitHubRemote(remote) {
 /**
  * Create the configuration file
  */
-function createConfigFile(projectId, apiKey, apiUrl, envInfo) {
+function createConfigFile(projectId, apiKey, apiUrl, envInfo, commitApiKey) {
     const config = {
         apiUrl: apiUrl,
         project: projectId,
@@ -245,10 +253,19 @@ function createConfigFile(projectId, apiKey, apiUrl, envInfo) {
         verbose: false
     };
 
-    // Only include apiKey in config if user wants it committed
-    // Otherwise it should be set via environment variable
-    // For now, we'll include it but note in .gitignore
-    config.apiKey = apiKey;
+    // The key is deliberately absent unless explicitly asked for.
+    //
+    // This file gets committed, and CI never reads the key from it — `init` sets
+    // SCRY_API_KEY as a GitHub *secret* and the generated workflow reads
+    // ${{ secrets.SCRY_API_KEY }}. So a copy here buys nothing and lands
+    // somewhere git history makes permanent: rotating the key afterwards does
+    // not remove it, and on a public repository it is simply disclosed.
+    //
+    // Local runs read SCRY_API_KEY from the environment, which lib/config.js
+    // already resolves.
+    if (commitApiKey) {
+        config.apiKey = apiKey;
+    }
 
     const configPath = '.storybook-deployer.json';
     fs.writeFileSync(
@@ -256,28 +273,6 @@ function createConfigFile(projectId, apiKey, apiUrl, envInfo) {
         JSON.stringify(config, null, 2) + '\n',
         'utf8'
     );
-}
-
-/**
- * Update .gitignore to exclude sensitive files (optional)
- */
-function updateGitignore() {
-    const gitignorePath = '.gitignore';
-    const entries = [
-        '# Scry Storybook Deployer',
-        '.storybook-deployer.json  # Contains API key'
-    ];
-
-    let gitignoreContent = '';
-    if (fs.existsSync(gitignorePath)) {
-        gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
-    }
-
-    // Check if already added
-    if (!gitignoreContent.includes('.storybook-deployer.json')) {
-        gitignoreContent += '\n' + entries.join('\n') + '\n';
-        fs.writeFileSync(gitignorePath, gitignoreContent, 'utf8');
-    }
 }
 
 /**
@@ -367,7 +362,7 @@ Or install GitHub CLI and run:
 /**
  * Commit the changes to git
  */
-function gitCommit(commitApiKey, logger) {
+function gitCommit(logger) {
     try {
         // Check if there are changes to commit
         const status = execSync('git status --porcelain', { encoding: 'utf8' });
@@ -381,10 +376,6 @@ function gitCommit(commitApiKey, logger) {
             '.github/workflows/deploy-pr-preview.yml',
             '.storybook-deployer.json'
         ];
-
-        if (!commitApiKey) {
-            filesToAdd.push('.gitignore');
-        }
 
         for (const file of filesToAdd) {
             if (fs.existsSync(file)) {
@@ -449,7 +440,7 @@ function showSuccessMessage(projectId, envInfo, apiUrl, pushed) {
 Your Storybook deployment is configured and ready to go.
 
 📦 What was set up:
-   ✅ Configuration file (.storybook-deployer.json)
+   ✅ Configuration file (.storybook-deployer.json — no credentials, safe to commit)
    ✅ GitHub Actions workflows (.github/workflows/)
    ✅ Repository variables (SCRY_PROJECT_ID, SCRY_API_URL)
    ✅ Repository secret (SCRY_API_KEY)
@@ -460,6 +451,12 @@ ${!pushed ? `
    Push your changes to GitHub:
    git push
 ` : ''}
+
+🔑 Running a deploy locally:
+   CI reads the key from the SCRY_API_KEY secret. On your own machine, export it
+   rather than writing it into the config file, which is committed:
+
+   export SCRY_API_KEY=<your key>
 
 🚀 Deployment:
    Your Storybook will deploy automatically on:
@@ -477,4 +474,4 @@ Happy deploying! ✨
 `);
 }
 
-module.exports = { runInit };
+module.exports = { runInit, createConfigFile };

--- a/test/init-credentials.test.js
+++ b/test/init-credentials.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const init = require('../lib/init.js');
+
+/**
+ * ISSUES.md #23.
+ *
+ * `init` wrote the API key into `.storybook-deployer.json`, skipped the
+ * `.gitignore` update, and committed the file — because `--commit-api-key`
+ * described itself as "not recommended" and defaulted to true.
+ *
+ * The copy was never needed. `init` sets SCRY_API_KEY as a GitHub *secret* and
+ * the workflow it generates reads `${{ secrets.SCRY_API_KEY }}`, so CI never
+ * looked at the config file for it. What the committed copy did achieve was
+ * putting a customer's credential somewhere git history makes permanent —
+ * rotating the key afterwards does not remove it, and on a public repository it
+ * is disclosed outright.
+ *
+ * These tests pin the default, because the default is the whole defect.
+ */
+describe('createConfigFile', () => {
+  let dir;
+  let cwd;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scry-init-'));
+    process.chdir(dir);
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function written() {
+    return JSON.parse(fs.readFileSync(path.join(dir, '.storybook-deployer.json'), 'utf8'));
+  }
+
+  it('omits the API key by default', () => {
+    init.createConfigFile('proj-1', 'test-key-placeholder-not-a-credential', 'https://api.example.com', {}, undefined);
+
+    const config = written();
+    expect(config.apiKey).toBeUndefined();
+    // The whole file is committed, so nothing in it may contain the key.
+    expect(JSON.stringify(config)).not.toContain('test-key-placeholder');
+  });
+
+  it('still writes the settings that are safe to commit', () => {
+    init.createConfigFile('proj-1', 'test-key-placeholder-not-a-credential', 'https://api.example.com', {}, false);
+
+    const config = written();
+    expect(config.project).toBe('proj-1');
+    expect(config.apiUrl).toBe('https://api.example.com');
+    expect(config.dir).toBe('./storybook-static');
+  });
+
+  // The escape hatch stays, for anyone who deliberately wants the old
+  // behaviour — which is what the flag's own description advises against.
+  it('includes the key only when explicitly asked', () => {
+    init.createConfigFile('proj-1', 'test-key-placeholder-not-a-credential', 'https://api.example.com', {}, true);
+
+    expect(written().apiKey).toBe('test-key-placeholder-not-a-credential');
+  });
+});


### PR DESCRIPTION
Closes #23.

## What was wrong

`scry init` wrote the customer's API key into `.storybook-deployer.json` and committed it. The flag controlling that, `--commit-api-key`, described itself as *"not recommended"* and defaulted to `true`. The description and the default disagreed, and the default won.

The copy was never load-bearing. `init` already runs `gh secret set SCRY_API_KEY`, and the workflow it generates reads `${{ secrets.SCRY_API_KEY }}` — CI never looked at the config file for the key. What committing it achieved was putting a credential where git history keeps it: rotating the key afterwards does not remove it, and on a public repository it is disclosed outright.

**The opt-out did not work either.** Two further defects, both found while fixing this:

1. `createConfigFile` set `config.apiKey` unconditionally, so `--no-commit-api-key` still wrote the key.
2. The `.gitignore` entry it added was `.storybook-deployer.json  # Contains API key`. In `.gitignore`, `#` only starts a comment at the **beginning of a line**, so the pattern included the trailing text and matched nothing:

```
$ git check-ignore -v .storybook-deployer.json
(no output — never ignored)
```

So the safe path neither omitted the key nor ignored the file.

## What changed

- `--commit-api-key` now defaults to **false**. The escape hatch remains and now warns.
- `createConfigFile` takes the flag and sets `apiKey` only when asked.
- The `.gitignore` step is **removed** rather than repaired. With no credential in it, the config is project id and API URL — settings a team should share — so ignoring it would only stop teammates getting the config. `gitCommit` loses the parameter it no longer branches on.
- The success message points at `export SCRY_API_KEY` for local runs. Verified `lib/config.js` resolves that name (`SCRY_` prefix first, `STORYBOOK_DEPLOYER_` as fallback).

## Verification

Ran `init` against a scratch repo and inspected the resulting commit, not just the tests.

Default path — the committed config:

```json
{
  "apiUrl": "https://api.example.com",
  "project": "proj-abc",
  "dir": "./storybook-static",
  "version": "latest",
  "verbose": false
}
```

`git grep` for the key across the commit and the working tree: clean. No `.gitignore` written, because there is nothing to hide.

Opt-in path (`--commit-api-key`): key present as before, preceded by the warning.

85 tests pass, 3 of them new and pinning the default.

## For the changelog

Anyone who ran an earlier version should **rotate that project's API key** — changing the file does not remove it from history. Called out in the changeset.