### PR TITLE
fix: stop reporting setup success that did not happen (#25)

### DIFF
--- a/.changeset/init-honest-setup-reporting.md
+++ b/.changeset/init-honest-setup-reporting.md
@@ -1,0 +1,22 @@
+---
+"@scrymore/scry-deployer": patch
+---
+
+`scry init` no longer reports success for steps that failed.
+
+Setting up a real repository end to end produced "✅ Changes committed and pushed"
+and "✅ Repository secret (SCRY_API_KEY)" while having done neither. CI then failed
+at the deploy step with no credentials, and the only clue was a warning printed
+twenty lines above the success banner that contradicted it.
+
+Three fixes:
+
+- **`git add` no longer aborts the commit.** It throws on a `.gitignore`'d path, and
+  one throw skipped the workflow files entirely. A leftover `.storybook-deployer.json`
+  ignore rule from the pre-0.4.0 workaround was enough to prevent CI ever being set up.
+- **`gh variable` is no longer assumed.** It arrived in gh 2.21; Ubuntu 22.04 ships
+  2.4.0. On older `gh` the first call threw and the secret after it was never reached,
+  leaving the repository with no variables *and* no secret. There is now a capability
+  check and a `gh api` fallback.
+- **The closing summary reports what happened**, including a distinct message for
+  "not attempted" when GitHub setup was skipped.

--- a/lib/init.js
+++ b/lib/init.js
@@ -79,14 +79,18 @@ async function runInit(argv) {
         logger.success('✅ Created .github/workflows/deploy-pr-preview.yml\n');
 
         // Step 6: Setup GitHub variables (if gh CLI available)
+        // Tracked, not assumed — the closing summary reports what actually happened.
+        let ghConfigured = null;
         const step6Start = Date.now();
         if (!argv.skipGhSetup && isGhCliAvailable()) {
             logger.info('6/8: Setting up GitHub repository variables...');
             try {
                 await setupGitHubVariables(argv.project, argv.apiKey, argv.apiUrl, logger);
+                ghConfigured = true;
                 const step6Duration = Date.now() - step6Start;
                 logger.success(`✅ GitHub variables configured [${step6Duration}ms]\n`);
             } catch (error) {
+                ghConfigured = false;
                 const step6Duration = Date.now() - step6Start;
                 logger.error(`⚠️  GitHub setup failed: ${error.message} [${step6Duration}ms]`);
                 logger.info('You can set these up manually later.\n');
@@ -126,7 +130,10 @@ async function runInit(argv) {
         logger.info('━'.repeat(50));
         logger.info(`[TIMING] Total setup time: ${totalDuration}ms (${(totalDuration / 1000).toFixed(2)}s)\n`);
         
-        showSuccessMessage(argv.project, envInfo, argv.apiUrl, pushResult.success);
+        showSuccessMessage(argv.project, envInfo, argv.apiUrl, pushResult.success, {
+            ghConfigured,
+            committed: commitResult.success,
+        });
 
     } catch (error) {
         logger.error(`\n❌ Setup failed: ${error.message}`);
@@ -313,22 +320,63 @@ function isGhCliAvailable() {
 /**
  * Setup GitHub variables using gh CLI
  */
-async function setupGitHubVariables(projectId, apiKey, apiUrl, logger) {
+/**
+ * Does this `gh` know about `gh variable`? It arrived in gh 2.21 (December 2022),
+ * and Ubuntu 22.04 still ships 2.4.0 — so plenty of machines do not have it.
+ * Without this check the very first call throws, the secret after it is never
+ * reached, and CI ends up with no credentials at all.
+ */
+function ghSupportsVariables() {
     try {
-        // Set variables
-        execSync(`gh variable set SCRY_PROJECT_ID --body "${projectId}"`, { stdio: 'pipe' });
-        logger.debug('   ✓ Set SCRY_PROJECT_ID');
-
-        execSync(`gh variable set SCRY_API_URL --body "${apiUrl}"`, { stdio: 'pipe' });
-        logger.debug('   ✓ Set SCRY_API_URL');
-
-        // Set secret (API key)
-        execSync(`gh secret set SCRY_API_KEY --body "${apiKey}"`, { stdio: 'pipe' });
-        logger.debug('   ✓ Set SCRY_API_KEY');
-
-    } catch (error) {
-        throw new Error(`Failed to set GitHub variables: ${error.message}`);
+        execSync('gh variable --help', { stdio: 'pipe' });
+        return true;
+    } catch {
+        return false;
     }
+}
+
+function setVariableViaApi(repo, name, value) {
+    // `gh api` predates `gh variable` by years, so it is the safe fallback.
+    const payload = JSON.stringify({ name, value });
+    try {
+        execSync(`gh api -X POST repos/${repo}/actions/variables --input -`, {
+            stdio: ['pipe', 'pipe', 'pipe'], input: payload,
+        });
+    } catch {
+        // Already present: update rather than create.
+        execSync(`gh api -X PATCH repos/${repo}/actions/variables/${name} --input -`, {
+            stdio: ['pipe', 'pipe', 'pipe'], input: payload,
+        });
+    }
+}
+
+async function setupGitHubVariables(projectId, apiKey, apiUrl, logger) {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe' })
+        .toString().trim();
+
+    const useCli = ghSupportsVariables();
+    if (!useCli) {
+        logger.debug('   gh is too old for `gh variable`; using `gh api` instead');
+    }
+
+    // Each of these is reported separately. A failure part-way through used to
+    // abandon the rest silently, which is how a repository ended up with the
+    // variables missing *and* the secret missing while setup reported success.
+    const setVar = (name, value) => {
+        if (useCli) execSync(`gh variable set ${name} --body "${value}"`, { stdio: 'pipe' });
+        else setVariableViaApi(repo, name, value);
+    };
+
+    setVar('SCRY_PROJECT_ID', projectId);
+    logger.debug('   ✓ Set SCRY_PROJECT_ID');
+
+    setVar('SCRY_API_URL', apiUrl);
+    logger.debug('   ✓ Set SCRY_API_URL');
+
+    // `gh secret set` needs libsodium encryption, so there is no simple `gh api`
+    // fallback — but it has existed since gh 1.x, so it works where variables do not.
+    execSync(`gh secret set SCRY_API_KEY --body "${apiKey}"`, { stdio: 'pipe' });
+    logger.debug('   ✓ Set SCRY_API_KEY');
 }
 
 /**
@@ -377,11 +425,24 @@ function gitCommit(logger) {
             '.storybook-deployer.json'
         ];
 
+        // Each file is staged on its own. `git add` fails on a path that
+        // .gitignore excludes, and one throw used to abort the loop before the
+        // commit — so a leftover `.storybook-deployer.json` ignore rule from the
+        // pre-0.4.0 workaround silently prevented the *workflows* being committed,
+        // and CI was never set up at all.
+        let staged = 0;
         for (const file of filesToAdd) {
-            if (fs.existsSync(file)) {
+            if (!fs.existsSync(file)) continue;
+            try {
                 execSync(`git add "${file}"`, { stdio: 'pipe' });
+                staged++;
                 logger.debug(`   ✓ Added ${file}`);
+            } catch {
+                logger.debug(`   • Skipped ${file} (ignored by .gitignore)`);
             }
+        }
+        if (staged === 0) {
+            return { success: false, message: 'Nothing could be staged' };
         }
 
         // Commit
@@ -433,7 +494,7 @@ function gitPush(logger) {
 /**
  * Show success message
  */
-function showSuccessMessage(projectId, envInfo, apiUrl, pushed) {
+function showSuccessMessage(projectId, envInfo, apiUrl, pushed, results = {}) {
     console.log(`
 🎉 ${pushed ? 'Setup Complete and Deployed!' : 'Setup Complete!'}
 
@@ -442,9 +503,14 @@ Your Storybook deployment is configured and ready to go.
 📦 What was set up:
    ✅ Configuration file (.storybook-deployer.json — no credentials, safe to commit)
    ✅ GitHub Actions workflows (.github/workflows/)
-   ✅ Repository variables (SCRY_PROJECT_ID, SCRY_API_URL)
-   ✅ Repository secret (SCRY_API_KEY)
-   ${pushed ? '✅ Changes committed and pushed' : '⚠️  Manual push required'}
+   ${results.ghConfigured === true
+        ? '✅ Repository variables and secret (SCRY_PROJECT_ID, SCRY_API_URL, SCRY_API_KEY)'
+        : results.ghConfigured === false
+            ? '❌ Repository variables and secret NOT set — CI cannot deploy until you fix this'
+            : '⚠️  Repository variables and secret not attempted — CI cannot deploy until you set them'}
+   ${results.committed === false
+        ? '❌ Changes NOT committed — the workflows are staged but uncommitted'
+        : (pushed ? '✅ Changes committed and pushed' : '⚠️  Committed; manual push required')}
 
 ${!pushed ? `
 📌 Next Step:
@@ -474,4 +540,4 @@ Happy deploying! ✨
 `);
 }
 
-module.exports = { runInit, createConfigFile };
+module.exports = { runInit, createConfigFile, gitCommit };

--- a/test/init-credentials.test.js
+++ b/test/init-credentials.test.js
@@ -65,3 +65,65 @@ describe('createConfigFile', () => {
     expect(written().apiKey).toBe('test-key-placeholder-not-a-credential');
   });
 });
+
+/**
+ * ISSUES.md #25.
+ *
+ * `init` printed a fixed success checklist regardless of what actually happened.
+ * Found by setting up a real GitHub repository end to end, where it reported
+ * "✅ Changes committed and pushed" and "✅ Repository secret" while having done
+ * neither — CI then failed at the deploy step with no credentials.
+ *
+ * Two independent causes, both fixed:
+ *   - `git add` throws on a .gitignore'd path, and one throw aborted the loop
+ *     before the workflows were staged.
+ *   - `gh variable` only exists from gh 2.21; on older gh the first call threw
+ *     and the secret after it was never reached.
+ *
+ * The tests below pin the reporting, because a wrong success message is worse
+ * than a failure: it stops the user looking.
+ */
+describe('gitCommit', () => {
+  const { execSync } = require('child_process');
+  let dir, cwd;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scry-commit-'));
+    process.chdir(dir);
+    execSync('git init -q . && git config user.email t@t.t && git config user.name t', { stdio: 'pipe' });
+    fs.writeFileSync('seed.txt', 'x');
+    execSync('git add -A && git commit -qm seed', { stdio: 'pipe' });
+    fs.mkdirSync('.github/workflows', { recursive: true });
+    fs.writeFileSync('.github/workflows/deploy-storybook.yml', 'name: deploy\n');
+    fs.writeFileSync('.github/workflows/deploy-pr-preview.yml', 'name: preview\n');
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const silent = { debug() {}, info() {}, success() {}, error() {} };
+
+  // The exact shape that broke a real repository: a leftover ignore rule from
+  // the pre-0.4.0 workaround stopped the workflows being committed at all.
+  it('still commits the workflows when the config file is gitignored', () => {
+    fs.writeFileSync('.gitignore', '.storybook-deployer.json\n');
+    fs.writeFileSync('.storybook-deployer.json', '{}');
+
+    const result = init.gitCommit(silent);
+
+    expect(result.success).toBe(true);
+    const tracked = execSync('git ls-tree -r HEAD --name-only', { encoding: 'utf8' });
+    expect(tracked).toContain('.github/workflows/deploy-storybook.yml');
+    expect(tracked).toContain('.github/workflows/deploy-pr-preview.yml');
+    expect(tracked).not.toContain('.storybook-deployer.json');
+  });
+
+  it('reports failure rather than success when nothing could be staged', () => {
+    fs.rmSync('.github', { recursive: true, force: true });
+
+    expect(init.gitCommit(silent).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #25. Found by creating a GitHub repository and setting Scry up on it — the first time the **CI path** was exercised end to end rather than the local one.

## What happened

`scry init` finished with:

```
📦 What was set up:
   ✅ Repository variables (SCRY_PROJECT_ID, SCRY_API_URL)
   ✅ Repository secret (SCRY_API_KEY)
   ✅ Changes committed and pushed
```

None of it was true:

```
$ gh api repos/.../actions/secrets    → {"total_count":0,"secrets":[]}
$ gh api repos/.../actions/variables  → {"total_count":0,"variables":[]}
$ git ls-tree -r HEAD --name-only | grep -c workflows → 0
```

The workflows were staged but uncommitted. Once committed by hand, CI failed at **Deploy to Scry** with no credentials. `init`'s own step 7 had said `⚠️ Could not commit automatically` — seven lines above the banner claiming the opposite.

## Three causes

**1. `git add` aborted the commit.** It throws on a `.gitignore`'d path, and the loop had no per-file handling, so one throw skipped everything after it *including the workflow files*. The repo carried a leftover `.storybook-deployer.json` ignore rule from the pre-0.4.0 workaround — enough on its own to stop CI ever being configured. Each file is now staged independently; ignored paths are skipped with a note.

**2. `gh variable` was assumed to exist.** It arrived in gh **2.21** (Dec 2022); Ubuntu 22.04 ships **2.4.0**. The first call threw, so `gh secret set` after it never ran, leaving neither variables nor secret. Now there's a capability check and a `gh api` fallback.

**3. The summary was decorative** — a fixed checklist of ticks, independent of results. It now takes real outcomes and distinguishes *not attempted* from *failed*.

## Verification

Reproduced the failure, then confirmed the fix against the same repo shape:

```
7/8: Committing changes...
   • Skipped .storybook-deployer.json (ignored by .gitignore)
✅ Changes committed: 4ec92f7
--- workflows in HEAD: 2
```

Skip path now reads:

```
⚠️  Repository variables and secret not attempted — CI cannot deploy until you set them
```

87 tests pass, 2 new ones pinning the reporting rather than the internals.

## Note

Third false-success found this week, after #24. A wrong success message is worse than a failure because it stops the user looking — worth sweeping for other fixed summaries.