### PR TITLE
fix: fail when --with-analysis produces no metadata (#24)

### DIFF
--- a/.changeset/fail-when-analysis-produces-nothing.md
+++ b/.changeset/fail-when-analysis-produces-nothing.md
@@ -1,0 +1,21 @@
+---
+"@scrymore/scry-deployer": minor
+---
+
+A deploy that was asked for `--with-analysis` now fails when analysis produces
+nothing.
+
+Previously it printed `✅ Upload successful!` and exited 0. No metadata archive
+meant nothing was queued, so no component ever became searchable — and because
+the indexing notice only prints when metadata *was* sent, there was no output at
+all to distinguish it from a healthy run. CI stayed green. The first sign of
+trouble was search returning nothing, days later.
+
+**This is a behaviour change:** the command now exits non-zero in that state. The
+Storybook is still uploaded and hosted, so "failure" overstates it slightly — but
+the job asked for was to make components searchable, and a green build there means
+search silently returns nothing.
+
+Common causes, both seen in practice: a missing Playwright browser (fixed for
+generated workflows in 0.4.1), and a TypeScript resolution error in the analyzer
+on a plain `npm install` tree.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -147,6 +147,30 @@ async function runDeployment(argv) {
                 '\n⚠️  Metadata was uploaded but not queued for processing.\n' +
                 '   The Storybook is hosted, but its components are NOT being indexed.'
             );
+        } else if (argv.withAnalysis) {
+            // The gap between the two branches above, and the most damaging
+            // state of the three: analysis was asked for, produced nothing, and
+            // this command used to say "Upload successful" and stop. Nothing is
+            // ever indexed, no error is printed, and CI stays green — so the
+            // first sign of trouble is a customer reporting that search is empty
+            // days later (ISSUES.md #24).
+            //
+            // Exit non-zero. The Storybook is hosted, so "failure" overstates it
+            // slightly, but the job asked for was to make components searchable
+            // and that did not happen. A red build is the only signal that gets
+            // acted on.
+            process.exitCode = 1;
+            logger.error(
+                '\n❌ Analysis produced no metadata, so NOTHING WILL BE INDEXED.\n' +
+                '   The Storybook is hosted and browsable, but no component will be\n' +
+                '   searchable from this build.\n\n' +
+                '   You asked for --with-analysis and it did not complete. The cause is\n' +
+                '   in the coverage output above — commonly a missing Playwright browser\n' +
+                '   (run: npx playwright install chromium-headless-shell) or a TypeScript\n' +
+                '   resolution error in the analyzer.\n\n' +
+                '   Exiting non-zero deliberately: a green build here would mean search\n' +
+                '   silently returns nothing.'
+            );
         }
 
     } finally {

--- a/test/cli-deployment.test.js
+++ b/test/cli-deployment.test.js
@@ -69,6 +69,54 @@ describe('bin/cli runDeployment()', () => {
       expect(out).toContain('NOT being indexed');
     });
 
+    // ISSUES.md #24. The gap between "queued" and "uploaded but not queued":
+    // analysis was requested, produced nothing, and the command reported plain
+    // success. Nothing is ever indexed and CI stays green, so the first sign of
+    // trouble is a customer saying search is empty days later.
+    test('fails loudly when analysis was requested but produced no metadata', async () => {
+      mockDeps(jest.fn().mockResolvedValue({
+        zipUpload: { success: true },
+        coverageUpload: null,
+        metadataUpload: null,
+      }));
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const previousExitCode = process.exitCode;
+
+      const { runDeployment } = require('../bin/cli.js');
+      await runDeployment({ ...baseArgs, withAnalysis: true });
+
+      const out = [...log.mock.calls, ...warn.mock.calls, ...err.mock.calls]
+        .map((c) => String(c[0])).join('\n');
+      expect(out).toContain('NOTHING WILL BE INDEXED');
+      // A green build here would mean search silently returns nothing.
+      expect(process.exitCode).toBe(1);
+
+      process.exitCode = previousExitCode;
+    });
+
+    // The quiet path stays quiet: no analysis asked for, none expected.
+    test('stays silent when analysis was never requested', async () => {
+      mockDeps(jest.fn().mockResolvedValue({
+        zipUpload: { success: true },
+        coverageUpload: null,
+        metadataUpload: null,
+      }));
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const previousExitCode = process.exitCode;
+
+      const { runDeployment } = require('../bin/cli.js');
+      await runDeployment({ ...baseArgs, withAnalysis: false });
+
+      const out = [...log.mock.calls, ...err.mock.calls].map((c) => String(c[0])).join('\n');
+      expect(out).not.toContain('NOTHING WILL BE INDEXED');
+      expect(process.exitCode).not.toBe(1);
+
+      process.exitCode = previousExitCode;
+    });
+
     test('stays quiet about indexing when no metadata was uploaded', async () => {
       mockDeps(jest.fn().mockResolvedValue({
         zipUpload: { success: true },


### PR DESCRIPTION
Closes #24 (the reporting half). The last of four false-success bugs found this week.

## The gap

The command already handled two of three states:

| State | Behaviour |
|---|---|
| Metadata queued | `⏳ Indexing has been queued, not finished` |
| Metadata uploaded, not queued | `⚠️ Metadata was uploaded but not queued` |
| **Metadata never produced** | **nothing** |

The third printed `✅ Upload successful!` and exited 0. Nothing is indexed, nothing becomes searchable — and the indexing notice never prints, because it's conditional on metadata having been sent. So the output is *indistinguishable from a healthy run*.

Found during the clean-account run: a fresh repo installed with `npm` crashed the analyzer, and the deploy still reported success. Downstream confirmed — the project recorded `storybook_uploaded` and nothing else, ever.

## Now

```
❌ Analysis produced no metadata, so NOTHING WILL BE INDEXED.
   The Storybook is hosted and browsable, but no component will be
   searchable from this build.

   You asked for --with-analysis and it did not complete. The cause is
   in the coverage output above — commonly a missing Playwright browser
   (run: npx playwright install chromium-headless-shell) or a TypeScript
   resolution error in the analyzer.

   Exiting non-zero deliberately: a green build here would mean search
   silently returns nothing.
```

## Behaviour change, deliberately

**The command now exits non-zero in that state.** The Storybook is still uploaded and hosted, so "failure" overstates it slightly — but the job asked for was to make components searchable, and a green build there means search silently returns nothing. A red build is the only signal anyone acts on.

Marked `minor` rather than `patch` for that reason.

The no-analysis path is untouched: if you didn't ask for analysis, absence of metadata is expected and stays silent.

## Verification

Run against the exact repository that produced the silent success this morning:

```
EXIT CODE: 1
❌ Analysis produced no metadata, so NOTHING WILL BE INDEXED.
...
🧹 Cleaned up temporary file: ...
```

Cleanup still runs — `process.exitCode` rather than `process.exit`, so the `finally` block completes.

94 tests pass, 2 new: one pinning the loud failure and the exit code, one pinning that the no-analysis path stays quiet.

## Note

Fourth bug this week with the same shape — a green message over a broken outcome (#24, #25, #26, and the `waitUntil` event drops). The common cause is that nothing in the system distinguished *deployed* from *indexed*. This closes the CLI side of that.

`#24a` — the analyzer crashing on an `npm`-installed tree instead of degrading — remains open and belongs in sbcov.