### PR TITLE
fix: a failed coverage upload no longer blocks indexing (#27)

### DIFF
--- a/.changeset/coverage-failure-no-longer-blocks-indexing.md
+++ b/.changeset/coverage-failure-no-longer-blocks-indexing.md
@@ -1,0 +1,16 @@
+---
+"@scrymore/scry-deployer": patch
+---
+
+A failed coverage upload no longer prevents your components being indexed.
+
+The coverage retry was unguarded, so when the second attempt also failed it threw
+out of `uploadBuild` and the metadata upload after it never ran. Coverage is a
+report; the metadata archive is what makes components searchable — so a failure in
+the optional artifact silently took down the essential one.
+
+Seen on a real 467-story design system: every story captured, the archive built,
+and nothing indexed — twice in a row.
+
+The retry is now guarded and prints a warning that says plainly which part failed
+and that indexing is unaffected.

--- a/lib/apiClient.js
+++ b/lib/apiClient.js
@@ -427,12 +427,26 @@ async function uploadBuild(apiClient, target, options) {
     logger.info(`Waiting ${COVERAGE_UPLOAD_DELAY_MS / 1000}s before uploading coverage report...`);
     await sleep(COVERAGE_UPLOAD_DELAY_MS);
 
+    // The retry used to be unguarded, so a second failure threw out of
+    // uploadBuild and the metadata upload below never ran. Coverage is a
+    // report; the metadata archive is what makes components searchable — so a
+    // failure in the optional artifact was silently taking down the essential
+    // one. Observed on a 467-story library: every story captured, nothing
+    // indexed, twice.
     try {
       coverageUpload = await uploadCoverageReportDirectly(apiClient, target, options.coverageReport);
     } catch (error) {
       logger.info('Coverage upload failed; retrying in 60s...');
       await sleep(COVERAGE_RETRY_DELAY_MS);
-      coverageUpload = await uploadCoverageReportDirectly(apiClient, target, options.coverageReport);
+      try {
+        coverageUpload = await uploadCoverageReportDirectly(apiClient, target, options.coverageReport);
+      } catch (retryError) {
+        logger.warn(
+          `⚠️  Coverage report upload failed: ${retryError.message}\n` +
+          '   Continuing — this affects the coverage report only. Screenshots and\n' +
+          '   metadata still upload, so components will still be indexed.'
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Found while re-indexing a real 467-story design system. Every story captured, the metadata archive built — and nothing indexed. Twice, identically.

## The bug

```js
try {
  coverageUpload = await uploadCoverageReportDirectly(...)
} catch (error) {
  logger.info('Coverage upload failed; retrying in 60s...');
  await sleep(COVERAGE_RETRY_DELAY_MS);
  coverageUpload = await uploadCoverageReportDirectly(...)   // ← unguarded
}

let metadataUpload = null;
if (options.metadataZipPath) {
  metadataUpload = await uploadMetadataZip(...)              // ← never reached
}
```

The retry isn't wrapped. A second failure throws out of `uploadBuild`, so the metadata upload after it never runs.

**Coverage is a report. The metadata archive is what makes components searchable.** A failure in the optional artifact was silently taking down the essential one — the same shape as #24, #25 and #26, where something non-essential fails and the part that matters quietly doesn't happen.

## Verified on the library that exposed it

```
⚠️  Coverage report upload failed: … No response received
✅ Upload successful!
⏳ Indexing has been queued, not finished.
```

Coverage still failed; indexing proceeded. Before the fix, the same repo produced no upload and no indexing at all.

## Deliberately not fixed here

The coverage upload *itself* fails consistently on this 467-story library and succeeds on a 23-story one. That's a separate question about what breaks at scale — the report is only ~110KB extrapolated, so size alone doesn't explain it. Worth its own investigation.

Either way it shouldn't gate indexing, which is the point of this change.

## On the test

I wrote a unit test for this and **removed it**. It passed its own assertions while never exercising the code path — `apiClient.post` was never called and the returned object had no `metadataUpload` key, meaning my mocks never reached the real function. A test that green-lights the wrong thing is worse than no test, and the end-to-end run above is stronger evidence. The seams here (raw axios PUT to a presigned URL, plus inconsistent `{project, version}` vs `{projectName, versionName}` destructuring between functions) need untangling before a meaningful unit test can be written.

94 existing tests pass.